### PR TITLE
fix(fetch_versions): remove stale failed_map reference after rename

### DIFF
--- a/scripts/fetch_versions.py
+++ b/scripts/fetch_versions.py
@@ -505,8 +505,7 @@ async def run(
 
     logger.info(
         f"To process: {len(work)}, already done: {len(done_set)}, "
-        f"skipped (failed≥{max_transient_failures}): "
-        f"{len([k for k, v in failed_map.items() if v >= max_transient_failures])}"
+        f"permanently dead (HTTP 500/4xx): {len(permanently_dead)}"
     )
 
     work = _apply_version_budget(work, version_budget)


### PR DESCRIPTION
The failed_map variable was renamed to permanently_dead in the completeness fix, but a log message on line 509 still referenced the old name, causing a NameError crash at shard startup before any fetching began.