### PR TITLE
ci: migrate GitHub Pages deployment to official actions

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -7,12 +7,17 @@ on:
     workflows: ["Pipeline"]
     types: [completed]
 
-concurrency:
-  group: build-pages
-  cancel-in-progress: true
-
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment, but don't cancel in-progress runs as we
+# want to allow these production deployments to complete.
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -64,21 +69,28 @@ jobs:
       - name: Install web deps
         run: pnpm --dir code/web install --frozen-lockfile
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
       - name: Build SPA
         env:
           VITE_BASE: /ley-chile/
           VITE_REPO: ${{ github.repository }}
         run: pnpm --dir code/web build
 
-      - name: Push to pages branch
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cd code/web/dist
-          git init -b pages
-          git config user.email "github-actions@users.noreply.github.com"
-          git config user.name "github-actions"
-          touch .nojekyll
-          git add -A
-          git commit -m "build: ${{ github.sha }}" --allow-empty
-          git push --force "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" HEAD:pages
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: code/web/dist
+
+  # Deployment job
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
Refactors the GitHub Pages deployment workflow to use GitHub's official `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages` actions instead of manual git operations. This aligns with GitHub's recommended best practices for Pages deployments.

## Key Changes
- **Permissions**: Updated to use the minimal required set (`contents: read`, `pages: write`, `id-token: write`) instead of `contents: write`
- **Concurrency**: Changed group from `build-pages` to `pages` and set `cancel-in-progress: false` to allow production deployments to complete
- **Build step**: Added `actions/configure-pages@v5` to prepare the Pages environment
- **Artifact handling**: Replaced manual git push logic with `actions/upload-pages-artifact@v3` to upload the built SPA (`code/web/dist`)
- **Deployment**: Introduced a separate `deploy` job that depends on `build`, using `actions/deploy-pages@v4` for the actual deployment with proper environment configuration

## Implementation Details
- The new workflow follows GitHub's standard two-job pattern: build artifacts, then deploy them
- The `deploy` job runs on `ubuntu-latest` with the `github-pages` environment, capturing the deployment URL in `steps.deployment.outputs.page_url`
- Removes the need for manual git configuration and token handling in the workflow
- Maintains the same build output path (`code/web/dist`) for the artifact upload

https://claude.ai/code/session_01VyfPdEZzHMZDqFuBofi4un