### PR TITLE
feat(scripts): tree-aware HTML→Markdown renderer for texto.md

### DIFF
--- a/scripts/build_history.py
+++ b/scripts/build_history.py
@@ -26,10 +26,8 @@ from __future__ import annotations
 
 import argparse
 import datetime
-import html as html_module
 import json
 import logging
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -53,6 +51,7 @@ from utils import (  # noqa: E402
     setup_logging,
 )
 from enrichers import Enricher  # noqa: E402
+from render_texto import render as render_texto  # noqa: E402
 
 log = logging.getLogger(__name__)
 
@@ -63,41 +62,6 @@ log = logging.getLogger(__name__)
 AUTHOR_NAME = "Ley Chile"
 AUTHOR_EMAIL = "leychile@bcn.cl"
 TARGET_BRANCH = "historial"
-
-_TAG_RE = re.compile(r"<[^>]+>")
-
-# ---------------------------------------------------------------------------
-# HTML → plain text
-# ---------------------------------------------------------------------------
-
-
-def _html_to_text(h: str) -> str:
-    """Strip HTML tags, decode entities, collapse whitespace."""
-    text = _TAG_RE.sub("", h)
-    text = html_module.unescape(text)
-    text = re.sub(r"\s+", " ", text).strip()
-    return text
-
-
-def _flatten_html(items: list) -> dict[int, str]:
-    """Recursively flatten html items to {part_id: html_text}."""
-    result: dict[int, str] = {}
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        if "i" in item and "t" in item:
-            result[item["i"]] = item["t"]
-        if "h" in item:
-            result.update(_flatten_html(item["h"]))
-    return result
-
-
-def _flatten_to_texto(items: list) -> str:
-    """Flatten html item tree to plain-text lines (no blank lines)."""
-    parts = _flatten_html(items)
-    lines = [_html_to_text(v) for v in parts.values() if v]
-    return "\n".join(line for line in lines if line)
-
 
 # ---------------------------------------------------------------------------
 # Timestamp helpers
@@ -433,7 +397,7 @@ def _version_files(
     files: dict[str, bytes] = {}
 
     if ver_data:
-        texto = _flatten_to_texto(ver_data.get("html", []))
+        texto = render_texto(ver_data.get("html", []))
         if texto:
             path = str(rel_dir / "texto.md")
             files[path] = texto.encode("utf-8")

--- a/scripts/render_texto.py
+++ b/scripts/render_texto.py
@@ -1,0 +1,384 @@
+"""HTML→Markdown renderer for Ley Chile texto.md files.
+
+Operates directly on the BCN HTML tree from cache/versions/{id}/{date}.json.
+
+Source structural conventions:
+  <div class="p">...</div>       — inciso (paragraph) inside an article
+  <span class="n">...</span>     — inline amendment ref (Ley N Art. M D.O. d.m.y).
+                                   STRIPPED per user request — git tracks the changes.
+  <div class="n rnp">...</div>   — inline NOTA back-link marker. STRIPPED.
+  <div class="np">...</div>      — actual NOTA body. Rendered as blockquote.
+
+Tree levels:
+  Each html[i] item may have children in 'h'. Typical:
+    depth 0: TÍTULO / CAPÍTULO sections OR document header/trailer
+    depth 1: Párrafo sections
+    depth 2: individual Artículos
+
+The item's 't' field is the chunk's own HTML; 'h' is its children.
+"""
+from __future__ import annotations
+
+import html as html_module
+import re
+from typing import Iterable
+
+# ---------------------------------------------------------------------------
+# Structural strippers (apply BEFORE generic tag-stripping)
+# ---------------------------------------------------------------------------
+
+# <span class="n">...</span> — amendment references
+_AMENDMENT = re.compile(
+    r"<span\s+class=[\"']n[\"'][^>]*>.*?</span>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# <div class="n rnp" ...>...</div> — inline NOTA back-link marker
+_NOTA_BACKLINK = re.compile(
+    r"<div\s+class=[\"']n\s+rnp[\"'][^>]*>.*?</div>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# <div class="np" ...>...</div> — NOTA body (capture group keeps content)
+_NOTA_BODY = re.compile(
+    r"<div\s+class=[\"']np[\"'][^>]*>(.*?)</div>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# <div class="p">...</div> — paragraph (inciso). Capture content.
+_PARAGRAPH = re.compile(
+    r"<div\s+class=[\"']p[\"'][^>]*>(.*?)</div>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Inline link to a NOTA marker (e.g. `<a href="#rnp0">NOTA:</a>`) inside <div class="np">
+_NOTA_INTERNAL_LINK = re.compile(r"<a[^>]*>NOTA:?</a>", re.IGNORECASE)
+
+# Generic tag stripper (applied last)
+_TAG = re.compile(r"<[^>]+>")
+
+# Collapse runs of whitespace (within a paragraph)
+_INLINE_WS = re.compile(r"[ \t ]+")
+
+
+def _strip_inline(text: str) -> str:
+    """Remove inline noise (amendment refs + nota back-links) BEFORE any
+    other tag work, so they don't splice into surrounding words."""
+    text = _AMENDMENT.sub("", text)
+    text = _NOTA_BACKLINK.sub("", text)
+    return text
+
+
+def _decode_entities_and_normalize(text: str) -> str:
+    text = html_module.unescape(text)
+    text = _INLINE_WS.sub(" ", text)
+    return text.strip()
+
+
+def _strip_tags(text: str) -> str:
+    return _TAG.sub("", text)
+
+
+# ---------------------------------------------------------------------------
+# Render a single 't' chunk (the HTML body of one tree item) into a list of
+# markdown paragraphs.
+# ---------------------------------------------------------------------------
+
+
+def _render_chunk(t: str) -> list[str]:
+    """Yield clean markdown paragraphs from one html 't' chunk."""
+    # 1) Strip inline amendment refs and nota back-links first.
+    t = _strip_inline(t)
+
+    # 2) Extract NOTA bodies as separate blockquoted paragraphs. We replace
+    #    each NOTA block with a sentinel that we'll expand later, so it
+    #    doesn't get absorbed into the surrounding article body.
+    notas: list[str] = []
+
+    def _replace_nota(m):
+        body = m.group(1)
+        # Some NOTAs start with their own `<a href="#rnp...">NOTA:</a>` link;
+        # remove that so it doesn't end up as a bare "NOTA" word.
+        body = _NOTA_INTERNAL_LINK.sub("", body)
+        body = _decode_entities_and_normalize(_strip_tags(body))
+        if body:
+            notas.append(body)
+        sentinel = f"\x00NOTA{len(notas) - 1}\x00"
+        return sentinel
+
+    t = _NOTA_BODY.sub(_replace_nota, t)
+
+    # 3) Now extract paragraphs (<div class="p">...</div>) as separate items.
+    paragraphs: list[str] = []
+    seen_indices: list[tuple[int, int]] = []
+    for m in _PARAGRAPH.finditer(t):
+        seen_indices.append((m.start(), m.end()))
+        body = _decode_entities_and_normalize(_strip_tags(m.group(1)))
+        if body:
+            paragraphs.append(body)
+
+    # 4) If there are no <div class="p"> wrappers (e.g. a bare TÍTULO chunk
+    #    is just text inside a top-level <div>), fall back to stripping
+    #    tags and treating the whole thing as one paragraph.
+    if not paragraphs:
+        body = _decode_entities_and_normalize(_strip_tags(t))
+        if body:
+            paragraphs.append(body)
+
+    # 5) Expand NOTA sentinels into blockquoted paragraphs RIGHT AFTER the
+    #    paragraph that contains them, so the note stays attached to its
+    #    referring inciso. If the sentinel never landed inside a paragraph
+    #    (shouldn't happen with current structure), append at the end.
+    out: list[str] = []
+    used = set()
+    for p in paragraphs:
+        # Sentinels may appear inside p as residual text
+        s_match = re.search(r"\x00NOTA(\d+)\x00", p)
+        if s_match:
+            idx = int(s_match.group(1))
+            clean = re.sub(r"\x00NOTA\d+\x00", "", p).strip()
+            if clean:
+                out.append(clean)
+            if 0 <= idx < len(notas):
+                out.append("> **Nota.** " + notas[idx])
+                used.add(idx)
+        else:
+            out.append(p)
+    for i, nota in enumerate(notas):
+        if i not in used:
+            out.append("> **Nota.** " + nota)
+
+    # Merge a bare section marker like "§ I." with its following paragraph
+    # (the BCN cache splits them across two <div class="p"> blocks).
+    merged: list[str] = []
+    i = 0
+    while i < len(out):
+        cur = out[i]
+        m = re.match(r"^§?\s*([IVX]{1,4})\.?\s*$", cur.strip())
+        if m and i + 1 < len(out) and not out[i + 1].startswith(("#", ">", "-")):
+            merged.append(m.group(1) + ". " + out[i + 1].strip().rstrip("."))
+            i += 2
+        else:
+            merged.append(cur)
+            i += 1
+    return [p for p in merged if p]
+
+
+# ---------------------------------------------------------------------------
+# Heading promotion
+# ---------------------------------------------------------------------------
+
+_RX_LIBRO = re.compile(
+    r"^LIBRO\s+(PRIMERO|SEGUNDO|TERCERO|CUARTO|QUINTO|SEXTO|S[ÉE]PTIMO|OCTAVO|NOVENO|D[ÉE]CIMO|[IVXLCDM]+|\d+)\b\s*[\.\-—:]?\s*(.*)$",
+    re.IGNORECASE,
+)
+_RX_TITULO = re.compile(
+    r"^(?:TÍTULO|TITULO)\s+(PRIMERO|SEGUNDO|TERCERO|CUART[O0]|QUINTO|SEXTO|S[ÉE]PTIMO|OCTAVO|NOVENO|D[ÉE]CIMO|PRELIMINAR|[IVXLCDM]+|\d+)\b\s*[\.\-—:]?\s*(.*)$",
+    re.IGNORECASE,
+)
+_RX_CAPITULO = re.compile(
+    r"^(?:Capítulo|Capitulo|CAPÍTULO|CAPITULO)\s+([IVXLCDM\d][-IVXLCDM\d.]*?)(?:\s+[—:]\s+(.*))?$",
+    re.IGNORECASE,
+)
+_RX_PARRAFO = re.compile(
+    r"^(?:Párrafo|Parrafo|PÁRRAFO|PARRAFO)\s+(\d+[ºo°]?|[IVXLCDM]+)\s*[-—:]?\s*(.*)$",
+    re.IGNORECASE,
+)
+# Roman-numeral subsection inside a Código (e.g. "I. De los delitos.").
+# Anchored so it doesn't fire on stray Roman numerals mid-text.
+_RX_ROMAN_SUBSECTION = re.compile(
+    r"^(?:§\s+|(?:Parte|PARTE|parte)\s+)?([IVX]{1,4})\.\s+([A-ZÁÉÍÓÚÑ][^.]{4,140})\.?$",
+)
+
+_RX_NUMBERED_SUBSECTION = re.compile(
+    r"^(?:§\s+)?(\d{1,2})\.\s+([A-ZÁÉÍÓÚÑ][^.]{4,70})\.?$",
+)
+_RX_BARE_SECTION_MARK = re.compile(r"^§?\s*([IVX]{1,4})\.?\s*$")
+_RX_ARTICULO_START = re.compile(
+    r"^(?:Artículo|Articulo|ART(?:ÍCULO|ICULO)?\.?)\s+(\d+[ºo°]?(?:\s*(?:bis|ter|quáter|quater|BIS|TER|QU[ÁA]TER))?|[úu]nico|transitorio|primero|segundo|tercero|cuarto|quinto|sexto|s[ée]ptimo|octavo|noveno|d[ée]cimo|final)\s*[-—.:]*\s*(.*)$",
+    re.IGNORECASE,
+)
+_RX_ARTICULOS_TRANS = re.compile(r"^Artículos\s+transitorios?$", re.IGNORECASE)
+
+
+def _maybe_promote_heading(para: str, depth: int = 0, suppress_subsection: bool = False) -> list[str]:
+    """If a single paragraph is or starts with a structural heading, split it."""
+    p = para.strip()
+    # Strip leading quotation marks / spurious punctuation so e.g.
+    # '"Artículo único.- ...' still matches.
+    p = re.sub(r'^["“”«»‚‹›\s]+', "", p)
+
+    m = _RX_LIBRO.match(p)
+    if m:
+        num, rest = m.group(1).strip(), m.group(2).strip()
+        if num.isalpha() and not set(num.upper()).issubset(set("IVXLCDM")):
+            num = num.title()
+        else:
+            num = num.upper()
+        title = f"# Libro {num}"
+        if rest:
+            return [title, rest]
+        return [title]
+
+    m = _RX_TITULO.match(p)
+    if m:
+        num, rest = m.group(1).strip(), m.group(2).strip()
+        # Title-case Spanish ordinals (PRIMERO -> Primero); keep Roman
+        # numerals uppercase. Roman = pure I/V/X/L/C/D/M.
+        if num.isalpha() and not set(num.upper()).issubset(set("IVXLCDM")):
+            num = num.title()
+        else:
+            num = num.upper()
+        title = f"## Título {num}"
+        if rest and not rest.lower().startswith(("art", "párrafo", "parrafo", "capítulo")):
+            title = f"## Título {num} — {rest}"
+            return [title]
+        return [title] + ([rest] if rest else [])
+
+    m = _RX_CAPITULO.match(p)
+    if m:
+        num = m.group(1).strip()
+        rest = (m.group(2) or "").strip()
+        title = f"## Capítulo {num}"
+        if rest:
+            title = f"## Capítulo {num} — {rest}"
+        return [title]
+
+    m = _RX_PARRAFO.match(p)
+    if m:
+        num, rest = m.group(1), m.group(2).strip()
+        title = f"### Párrafo {num}"
+        if rest:
+            title = f"### Párrafo {num} — {rest}"
+        return [title]
+
+    # Roman subsections (incl. "Parte X.") are always allowed —
+    # they tend to be true structural dividers even inside long chunks.
+    m = _RX_ROMAN_SUBSECTION.match(p)
+    if m:
+        prefix = ""
+        head = p[:m.start(1)].strip()
+        if head.lower().startswith("parte"):
+            prefix = "Parte "
+        return [f"### {prefix}{m.group(1)}. {m.group(2).strip()}"]
+    # Arabic-numbered subsections are list-item-shaped, so suppress them
+    # once we've already emitted an Artículo heading in the same chunk.
+    if not suppress_subsection:
+        m = _RX_NUMBERED_SUBSECTION.match(p)
+        if m:
+            return [f"### {m.group(1)}. {m.group(2).strip()}"]
+
+    if _RX_ARTICULOS_TRANS.match(p):
+        return ["## Artículos transitorios"]
+
+    m = _RX_ARTICULO_START.match(p)
+    if m:
+        num = m.group(1).strip()
+        # Normalize BIS/TER suffix case for consistency
+        num = re.sub(r"\b(BIS|TER|QU[ÁA]TER)\b", lambda mm: mm.group(1).lower(), num)
+        body = m.group(2).strip()
+        # Old codes like 1888 Código de Minería write "ART. 1.°" — the ordinal
+        # symbol ends up captured as the body. Absorb it into the number.
+        if re.fullmatch(r"[°ºo]", body):
+            if not re.search(r"[°ºo]$", num):
+                num = num + "°"
+            body = ""
+        out = [f"#### Artículo {num}"]
+        if body:
+            out.append(body)
+        return out
+
+    return [para]
+
+
+# ---------------------------------------------------------------------------
+# List markers within paragraphs
+# ---------------------------------------------------------------------------
+
+_LETTER_ITEM = re.compile(r"(?<=[\s.;:])\b([a-z])\)\s+", re.IGNORECASE)
+_NUMBER_ITEM = re.compile(r"(?<=[\s.;:])\b(\d+)\.-\s+")
+
+
+def _break_lists(paragraph: str) -> list[str]:
+    """If a paragraph contains multiple lettered or numbered list items
+    running together, split them into separate markdown bullet items."""
+    letter_marks = list(_LETTER_ITEM.finditer(paragraph))
+    number_marks = list(_NUMBER_ITEM.finditer(paragraph))
+
+    # Require ≥3 markers — 2 alone too often gets triggered by stray dates
+    # ("Núm. 1.- Santiago, 14 de Julio de 1970.-") or footnote-style references.
+    marks = letter_marks if len(letter_marks) >= 3 else (number_marks if len(number_marks) >= 3 else [])
+    if len(marks) < 3:
+        return [paragraph]
+
+    out: list[str] = []
+    intro = paragraph[: marks[0].start()].strip()
+    if intro:
+        out.append(intro)
+    for i, m in enumerate(marks):
+        next_start = marks[i + 1].start() if i + 1 < len(marks) else len(paragraph)
+        marker = m.group(0).strip()
+        body = paragraph[m.end():next_start].strip()
+        if body:
+            out.append(f"- **{marker}** {body}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Top-level driver
+# ---------------------------------------------------------------------------
+
+
+def _walk_tree(items: Iterable, out: list[str], depth: int = 0) -> None:
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        t = item.get("t")
+        if t:
+            # Within one chunk, once an Artículo heading lands, suppress any
+            # further subsection promotion — list items like "11. Las..."
+            # inside an article body must stay as text, not headings.
+            article_seen = False
+            for para in _render_chunk(t):
+                for sub in _maybe_promote_heading(
+                    para, depth=depth, suppress_subsection=article_seen,
+                ):
+                    if sub.startswith("#### "):
+                        article_seen = True
+                    if sub.startswith(("#", ">", "- ")):
+                        out.append(sub)
+                    else:
+                        out.extend(_break_lists(sub))
+        children = item.get("h")
+        if isinstance(children, list):
+            _walk_tree(children, out, depth + 1)
+
+
+def render(html_items: list) -> str:
+    """Top-level: turn the BCN html tree into clean markdown."""
+    paragraphs: list[str] = []
+    _walk_tree(html_items, paragraphs)
+    # Collapse adjacent identical paragraphs (some normas duplicate)
+    deduped: list[str] = []
+    last = None
+    for p in paragraphs:
+        if p != last:
+            deduped.append(p)
+        last = p
+    return "\n\n".join(deduped).strip()
+
+
+# ---------------------------------------------------------------------------
+# CLI demo
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import json
+    import sys
+
+    path = sys.argv[1] if len(sys.argv) > 1 else None
+    if not path:
+        print("usage: renderer_v2.py <path-to-version.json>", file=sys.stderr)
+        sys.exit(2)
+    d = json.load(open(path))
+    print(render(d.get("html", [])))


### PR DESCRIPTION
## Summary

- Replaces the old blind tag-stripping renderer in `build_history.py` with a structural, tree-aware module in `scripts/render_texto.py`.
- The old pipeline produced unreadable runs — amendment refs spliced into surrounding words (\`Ar Ley 21575 ... t culo 5.-\`), NOTAs glued onto prose, no paragraphs, no headings.
- The new renderer walks the BCN html tree and exploits the four structural CSS classes (\`p\` / \`n\` / \`n rnp\` / \`np\`) to emit proper markdown with headings, paragraphs, blockquoted NOTAs, and amendment refs stripped.

### What changes in the output

| | Before | After |
|---|---|---|
| Format | Single line per inciso, no separation | Proper paragraphs (\`\n\n\`) |
| Headings | Inline (\`TITULO I De los...\`) | \`## Título I\` / \`### Párrafo 1º\` / \`#### Artículo 1º\` |
| Amendment refs | \`Ar Ley 21575 Art. 1 N 2 D.O. 23.05.2023 t culo 5.-\` spliced mid-word | Removed entirely (git tracks the changes) |
| NOTAs | \`NOTA De acuerdo...\` glued to prose | \`> **Nota.** De acuerdo...\` blockquote |
| Lists | \`a) X b) Y c) Z\` running together | Each \`a)\` / \`b)\` paragraph-separated |
| Codes | \`LIBRO PRIMERO TITULO PRIMERO ART. 1.\` flat | \`# Libro Primero\` → \`## Título Primero\` → \`#### Artículo 1°\` |

### Validation

Rendered 16 diverse samples without anomalies:
- **cod** — Civil 1855 (4 libros / 103 títulos / 140 subsections / 2,524 artículos / 47 NOTAs), Comercio 1865, Minería 1888, Penal modern + first version 1875
- **dl** — DL N°5 (1973 estado de sitio), DL 3500 (pensions, 184 NOTAs)
- **dfl** — DFL N°1 (1970, PARRAFO Roman caps)
- **dto** — Decreto 2024 Convenio with \`Parte I.\` Roman markers, Constitución Política (15 capítulos / 169 artículos)
- **ley** — sustantiva (Ley 20.000), modificatoria (21644 \`Artículo único\`), short modern (21684)
- **aa** — Auto Acordado 2020
- **cir** — Recopilación Bancos (3.3 MB, \`Capítulo 1-7\` composites)
- **acd** — Acuerdo Banco Central
- **avi** — Aviso (party declaration)
- **ley** — old Lei de Presupuestos 1893

### Edge cases handled

- Modificatoria amendment refs (\`<span class=\"n\">\`) → stripped
- NOTA bodies (\`<div class=\"np\">\`) → blockquoted and attached to referring inciso
- Roman numerals in TÍTULOs/CAPÍTULOs (kept uppercase: II not Ii)
- Spanish ordinals title-cased (PRIMERO → Primero)
- Word-numbered Artículos (\`único\`, \`transitorio\`)
- \`BIS\` / \`TER\` / \`QUÁTER\` suffixes (lowercased)
- \`ART. 1.°\` legacy ordinal form (ordinal absorbed)
- \`Parte I.\` Roman section markers
- Capítulo \`1-7\` composite numbers preserved (no dash split)
- \`§ I.\` + continuation paragraph merged
- Arabic-numbered subsection promotion suppressed inside Article bodies (no spurious \`### 11. Las operaciones de banco\`)
- Leading quote tolerated for \`\"Artículo único.-\`

### Code diff

- \`scripts/render_texto.py\` — **new**, 384 lines
- \`scripts/build_history.py\` — **-38 / +2**: removed \`_TAG_RE\`, \`_html_to_text\`, \`_flatten_html\`, \`_flatten_to_texto\`, plus unused \`html\` / \`re\` imports; added one import and changed call site

All 11 existing \`test_build_history_*\` tests still pass.

## Test plan

- [ ] CI green
- [ ] Spot-check one re-rendered \`texto.md\` on \`historial\` after re-running build_history
- [ ] Confirm diff payload of \`build_history.py --dry-run\` shrinks meaningfully on modificatoria commits (amendment refs no longer in body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)