### PR TITLE
fix(ci): NORMA_DIRS double-zero breaks full-rebuild detection

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -545,7 +545,11 @@ jobs:
           # Count real norma dirs from the ref itself (worktree files may be
           # stale from a prior build — fast-import updates the ref but doesn't
           # sync the worktree checkout).
-          NORMA_DIRS=$(git ls-tree --name-only -r refs/heads/historial 2>/dev/null | grep -c '/metadata\.json$' || echo 0)
+          # `grep -c` exits 1 when nothing matches, which made `|| echo 0`
+          # also fire, producing "0\n0" and breaking the -lt 100 test below.
+          # Wrap grep so empty matches stay 0 with exit 0.
+          NORMA_DIRS=$(git ls-tree --name-only -r refs/heads/historial 2>/dev/null | { grep -c '/metadata\.json$' || true; })
+          NORMA_DIRS=${NORMA_DIRS:-0}
           echo "Pre-build state: remote_tip=$REMOTE_TIP  local_W=$LOCAL_W  norma_dirs=$NORMA_DIRS  force_full=$FORCE_FULL"
 
           if [ "$FORCE_FULL" = "true" ] || [ -z "$REMOTE_TIP" ] || [ "$NORMA_DIRS" -lt 100 ]; then


### PR DESCRIPTION
## Summary

In the consolidate-and-build job:

```bash
NORMA_DIRS=$(git ls-tree ... | grep -c '/metadata\.json$' || echo 0)

grep -c writes the count (e.g. 0) to stdout AND exits 1 when no lines match, which makes the || echo 0 branch fire too — producing the value "0\n0". The next test then hits:

/home/runner/.../sh: line 38: [: 0\n0: integer expression expected

so [ "$NORMA_DIRS" -lt 100 ] evaluates falsy, and an empty historial silently picks "incremental" mode with watermark = today, building 0 events and pushing nothing.

Reproduction

Run #27245834311 (after PR #8 merged): pre-build state showed norma_dirs=0 but mode stayed incremental instead of falling through to full rebuild. Required passing full_rebuild=true to recover (run #27246459704).

Fix

Wrap grep in { ... || true; } so it always exits 0 and emits its real count. Belt-and-braces NORMA_DIRS=${NORMA_DIRS:-0} covers the edge case where git ls-tree itself fails (refs missing on a fresh runner).

NORMA_DIRS=$(git ls-tree ... | { grep -c '/metadata\.json$' || true; })
NORMA_DIRS=${NORMA_DIRS:-0}

Test plan

- [ ] Merge
- [ ] Force-reset historial to empty init; trigger Pipeline phase=consolidate-build WITHOUT full_rebuild=true
- [ ] Verify log shows Mode: full instead of Mode: incremental

🤖 Generated with Claude Code (https://claude.com/claude-code)
