### PR TITLE
seo: fix robots.txt sitemap directive 404ing on all sharded law URLs

### DIFF
--- a/site/app/robots.ts
+++ b/site/app/robots.ts
@@ -1,11 +1,18 @@
 import type { MetadataRoute } from 'next'
-import { SITE } from '@/lib/jsonld'
+import { SITE, MAX_SITEMAP_SHARDS } from '@/lib/site'
 
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [{ userAgent: '*', allow: '/', disallow: ['/api/'] }],
-    // Two sitemaps: the sharded law-URL index, and the content sitemap
-    // (guides / cambios / temas / blog). See app/sitemap-contenido.xml.
-    sitemap: [`${SITE}/sitemap.xml`, `${SITE}/sitemap-contenido.xml`],
+    // Two sitemaps: the sharded law-URL index (app/sitemap.ts), and the
+    // content sitemap (guides / cambios / temas / blog, see
+    // app/sitemap-contenido.xml). Next.js's generateSitemaps() convention
+    // serves shards at /sitemap/{id}.xml — there is NO index at the bare
+    // /sitemap.xml (that path 404s), so every shard must be listed here
+    // explicitly for crawlers to discover them from robots.txt.
+    sitemap: [
+      ...Array.from({ length: MAX_SITEMAP_SHARDS }, (_, i) => `${SITE}/sitemap/${i}.xml`),
+      `${SITE}/sitemap-contenido.xml`,
+    ],
   }
 }

--- a/site/app/sitemap.ts
+++ b/site/app/sitemap.ts
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic'
 
 import type { MetadataRoute } from 'next'
 import { pool } from '@/lib/db'
-import { SITE } from '@/lib/jsonld'
+import { SITE, MAX_SITEMAP_SHARDS } from '@/lib/site'
 import { canonicalHref, normaHref } from '@/lib/href'
 
 const PER_SITEMAP = 50_000   // Google's hard limit
@@ -20,8 +20,8 @@ const PER_SITEMAP = 50_000   // Google's hard limit
 // doubled by non-current versions) and over-provision. Shards beyond the
 // real data just return zero rows at request time (OFFSET past the end of a
 // result set, not an error) — Google gets a valid, empty sitemap for those,
-// which is harmless. Bump MAX_SITEMAP_SHARDS if the corpus outgrows it.
-const MAX_SITEMAP_SHARDS = 32
+// which is harmless. Bump MAX_SITEMAP_SHARDS (lib/site.ts) if the corpus
+// outgrows it — app/robots.ts lists every shard from the same constant.
 
 export async function generateSitemaps() {
   return Array.from({ length: MAX_SITEMAP_SHARDS }, (_, id) => ({ id }))

--- a/site/lib/site.ts
+++ b/site/lib/site.ts
@@ -21,3 +21,15 @@ export const MCP_PATH = '/api/mcp'
  *  fail for exactly the callers our MCP tools serve. Agent-facing text comes
  *  from this site's own endpoints. */
 export const REPO = 'https://github.com/pisanvs/ley-chile'
+
+/**
+ * Number of shards `app/sitemap.ts` pre-registers via `generateSitemaps()`.
+ * See the comment there for why this is a fixed over-provisioned count
+ * rather than a DB-derived one.
+ *
+ * Shared with `app/robots.ts`: Next.js's `generateSitemaps` convention does
+ * NOT serve an index at the bare `/sitemap.xml` — only at `/sitemap/{id}.xml`
+ * (confirmed: the bare path 404s in production). So robots.txt must list
+ * every shard URL explicitly instead of the single `/sitemap.xml` path.
+ */
+export const MAX_SITEMAP_SHARDS = 32


### PR DESCRIPTION
## Problem

`robots.txt` (`site/app/robots.ts`) declares:

```
Sitemap: https://leyes.pisanvs.cl/sitemap.xml
```

but that exact URL returns a genuine HTTP 404 in production:

```
$ curl -sI https://leyes.pisanvs.cl/sitemap.xml
HTTP/2 404
```

`app/sitemap.ts` uses Next.js's `generateSitemaps()` to shard the ~333k norma pages across 32 files. Per Next.js's own docs, that convention serves shards **only** at `/sitemap/{id}.xml` — there is no automatic index served at the bare `/sitemap.xml` path. Confirmed live:

```
/sitemap.xml     -> 404
/sitemap/0.xml   -> 200 (3600 <loc> entries)
/sitemap/1.xml   -> 200
```

So the one sitemap entry in `robots.txt` that's supposed to cover the entire law-URL corpus (canonical `/norma/{id}/{slug}` pages) points crawlers at a 404. `sitemap-contenido.xml` (guides/cambios/temas/blog, unaffected) is a separate, correctly-served route.

## Fix

List every shard URL explicitly in `robots.txt` instead of the single broken `/sitemap.xml` path, sharing the shard count with `app/sitemap.ts` via a new `MAX_SITEMAP_SHARDS` constant in `lib/site.ts` (previously a private const inside `app/sitemap.ts`) so the two can't drift apart.

- `lib/site.ts`: added `export const MAX_SITEMAP_SHARDS = 32` with a comment explaining why the shards are listed explicitly.
- `app/sitemap.ts`: imports `MAX_SITEMAP_SHARDS` from `lib/site` instead of declaring it locally.
- `app/robots.ts`: emits `${SITE}/sitemap/{i}.xml` for every shard, plus `${SITE}/sitemap-contenido.xml`.

Shards beyond real data already return a valid empty `<urlset>` (documented in `app/sitemap.ts`), so listing all 32 unconditionally is harmless.

## Verification

Run from `site/` with `DATABASE_URL` unset, per this repo's requirement that the build never need Postgres:

- `pnpm build` — green. Route table confirms no route serves the bare `/sitemap.xml` path (only `/sitemap/[__metadata_id__]` and `/sitemap-contenido.xml`).
- `npx tsc --noEmit` — clean.
- `pnpm vitest run` — 68 passed, 1 skipped (unchanged from before this change).
- Live `curl` against production confirmed the bug (`/sitemap.xml` → 404, `/sitemap/0.xml` and `/sitemap/1.xml` → 200) before writing the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P44iMEnQPJwHTJWSuTvW3B

---
_Generated by [Claude Code](https://claude.ai/code/session_01P44iMEnQPJwHTJWSuTvW3B)_