### PR TITLE
seo: collapse embedded newlines in título before it hits &lt;title&gt;/JSON-LD

### DIFF
--- a/site/app/guia/[...rest]/page.tsx
+++ b/site/app/guia/[...rest]/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { notFound, permanentRedirect } from 'next/navigation'
-import { breadcrumbJsonLd, faqJsonLd, jsonLdScript, legislationJsonLd, SITE, type FaqEntry } from '@/lib/jsonld'
+import {
+  breadcrumbJsonLd, cleanTitulo, faqJsonLd, jsonLdScript, legislationJsonLd, SITE, type FaqEntry,
+} from '@/lib/jsonld'
 import { cambiosHref, canonicalHref, guiaHref } from '@/lib/href'
 import {
   currentFecha, getModifiedBy, getModifies, getVersions,
@@ -37,7 +39,7 @@ function title(n: Norma): string {
 
 function description(n: Norma, versions: Version[]): string {
   const v = versions.length > 1 ? `${versions.length} versiones` : 'texto vigente'
-  return `${normaLabel(n)}: ${n.titulo.slice(0, 90)}. Publicada el ${fechaLarga(n.fechaPublicacion)} — ${v}, articulado completo e historial de modificaciones.`
+  return `${normaLabel(n)}: ${cleanTitulo(n.titulo).slice(0, 90)}. Publicada el ${fechaLarga(n.fechaPublicacion)} — ${v}, articulado completo e historial de modificaciones.`
 }
 
 export async function generateMetadata({ params }: Props) {
@@ -69,7 +71,7 @@ function buildFaq(
   const faq: FaqEntry[] = [
     {
       q: `¿Qué es la ${label}?`,
-      a: `${label} — «${n.titulo}». Fue publicada el ${fechaLarga(n.fechaPublicacion)}${n.organismo ? ` por ${n.organismo}` : ''}.`,
+      a: `${label} — «${cleanTitulo(n.titulo)}». Fue publicada el ${fechaLarga(n.fechaPublicacion)}${n.organismo ? ` por ${n.organismo}` : ''}.`,
     },
     {
       q: `¿Desde cuándo rige el texto actual de la ${label}?`,

--- a/site/app/norma/[id]/[[...rest]]/page.tsx
+++ b/site/app/norma/[id]/[[...rest]]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import { notFound, permanentRedirect } from 'next/navigation'
-import { SITE } from '@/lib/jsonld'
+import { cleanTitulo, SITE } from '@/lib/jsonld'
 import {
   canonicalPath, getAvisos, getCanonicalNorma, getKeySiblings, getNormaById,
   getRefundido, getVersions,
@@ -61,9 +61,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   // Self-canonical, always. canonicalPath collapses a dated URL onto the
   // undated one for single-version normas, which is most of the corpus.
   const canonical = fecha ? canonicalPath(norma, fecha, versions) : canonicalHref(norma)
+  const titulo = cleanTitulo(norma.titulo)
   const title = fecha
-    ? `${norma.titulo} — texto al ${fecha}`
-    : norma.organismo ? `${norma.titulo} — ${norma.organismo}` : norma.titulo
+    ? `${titulo} — texto al ${fecha}`
+    : norma.organismo ? `${titulo} — ${norma.organismo}` : titulo
   const description =
     `${normaLabel(norma)}${norma.organismo ? ` — ${norma.organismo}` : ''}. ` +
     `Publicada el ${fechaLarga(norma.fechaPublicacion)}. Texto completo, historial de versiones y modificaciones.`

--- a/site/lib/jsonld.test.ts
+++ b/site/lib/jsonld.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { legislationJsonLd, RESERVED_TIPOS } from './jsonld'
+import { cleanTitulo, legislationJsonLd, RESERVED_TIPOS } from './jsonld'
 import type { Norma, Version } from './norma'
 
 const LEY: Norma = {
@@ -37,6 +37,25 @@ describe('legislationJsonLd', () => {
   it('lists modifying normas under legislationChanges', () => {
     const ld = legislationJsonLd(LEY, '2011-01-02', versions, [99, 100]) as Record<string, unknown>
     expect(ld['legislationChanges']).toHaveLength(2)
+  })
+})
+
+describe('cleanTitulo', () => {
+  it('collapses embedded line breaks into single spaces', () => {
+    expect(cleanTitulo('AUTO ACORDADO SOBRE REINSCRIPCION DE PARTIDOS\nPOLITICOS EN UNA O MAS\nREGIONES'))
+      .toBe('AUTO ACORDADO SOBRE REINSCRIPCION DE PARTIDOS POLITICOS EN UNA O MAS REGIONES')
+  })
+
+  it('leaves an already-clean título unchanged', () => {
+    expect(cleanTitulo('LEY 20330')).toBe('LEY 20330')
+  })
+
+  it('emits the cleaned título as JSON-LD name', () => {
+    const versions: Version[] = [{ desde: '2009-02-25', hasta: null, commitSha: 'a', causaId: null, subject: '' }]
+    const ld = legislationJsonLd(
+      { ...LEY, titulo: 'LEY 20330\nSOBRE ALGO' }, '2009-02-25', versions, [],
+    ) as Record<string, unknown>
+    expect(ld['name']).toBe('LEY 20330 SOBRE ALGO')
   })
 })
 

--- a/site/lib/jsonld.ts
+++ b/site/lib/jsonld.ts
@@ -17,6 +17,17 @@ export const RESERVED_TIPOS = new Set([
   'guia', 'cambios', 'temas', 'blog', 'norma',
 ])
 
+/** Some títulos are stored with the line breaks the BCN source wrapped them
+ *  across (long official names of decretos/acuerdos especially). Collapse
+ *  those before the string lands in a <title>/og:title/JSON-LD text field —
+ *  those are read as literal attribute/text values, not HTML-rendered, so a
+ *  raw newline shows up as a stray line break in search snippets and social
+ *  cards instead of being invisibly absorbed the way it is in rendered page
+ *  body copy. */
+export function cleanTitulo(s: string): string {
+  return s.replace(/\s+/g, ' ').trim()
+}
+
 export function legislationJsonLd(
   n: Norma, fecha: string, versions: Version[], modifiedBy: number[],
 ): object {
@@ -24,7 +35,7 @@ export function legislationJsonLd(
   return {
     '@context': 'https://schema.org',
     '@type': 'Legislation',
-    name: n.titulo,
+    name: cleanTitulo(n.titulo),
     legislationIdentifier: n.numero,
     legislationType: n.tipo,
     legislationDate: n.fechaPublicacion,


### PR DESCRIPTION
## Problem

Some normas' `titulo` is stored with the line breaks the BCN source wrapped it across — long official names of decretos/acuerdos especially. Confirmed live, idNorma 32:

```html
<title>AUTO ACORDADO SOBRE REINSCRIPCION DE PARTIDOS
POLITICOS EN UNA O MAS REGIONES DEL PAIS ARTICULO 17 LEY
N° 18.603 — TRIBUNAL CALIFICADOR DE ELECCIONES · LeyChile</title>
```

Same raw newline shows up verbatim in `og:title`. `<title>`/`og:title`/JSON-LD text fields are read as literal attribute/text values, not HTML-rendered — unlike visible page body copy, where the browser's default `white-space: normal` already collapses this invisibly. So this surfaces as a stray line break in Google search snippets and social-card previews (Twitter/Facebook read `og:title` raw).

## Fix

Added `lib/jsonld.ts#cleanTitulo` (collapse whitespace runs to a single space, trim) and applied it at the three call sites that put a raw `titulo` into such a field:

- `app/norma/[id]/[[...rest]]/page.tsx` — the reader page's `<title>`/`og:title`.
- `lib/jsonld.ts` `legislationJsonLd` — the JSON-LD `name` field.
- `app/guia/[...rest]/page.tsx` — the meta description (`n.titulo.slice(0, 90)`) and the FAQ answer text (which also feeds `FAQPage` JSON-LD).

Left visible JSX body headings (`{n.titulo}` in `LawView`, `/cambios`, `/temas`) untouched — those already render correctly as-is, so touching them would be scope creep with no visible benefit.

## Verification

Run from `site/` with `DATABASE_URL` unset:

- `npx tsc --noEmit` — clean.
- `pnpm vitest run` — 71 passed, 1 skipped (68 existing + 3 new `cleanTitulo` tests, including one asserting `legislationJsonLd`'s `name` comes out cleaned).
- `pnpm build` — green, route table unchanged, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P44iMEnQPJwHTJWSuTvW3B

---
_Generated by [Claude Code](https://claude.ai/code/session_01P44iMEnQPJwHTJWSuTvW3B)_