### PR TITLE
seo: noindex /buscar result pages, keep the bare search entry indexable

### DIFF
--- a/site/app/buscar/page.tsx
+++ b/site/app/buscar/page.tsx
@@ -1,8 +1,22 @@
 import { Suspense } from 'react'
+import type { Metadata } from 'next'
 import Link from 'next/link'
 import { recordEvent } from '@/lib/analytics'
 import { normalizeQuery, runSearch, type Hit } from '@/lib/search'
 import { canonicalHref } from '@/lib/href'
+
+interface SearchParamsProps { searchParams: Promise<{ q?: string; asOf?: string }> }
+
+// The bare /buscar entry page (a real, if thin, "search this corpus" page) stays
+// indexable. Every ?q= result page noindexes: search results are a query-shaped
+// view over content that already has its own canonical page (the norma itself),
+// so indexing them creates duplicate/thin pages competing with those canonicals
+// across an effectively unbounded number of query strings — one of the more
+// common ways a site drags down its own average quality signal in Google's eyes.
+export async function generateMetadata({ searchParams }: SearchParamsProps): Promise<Metadata> {
+  const { q } = await searchParams
+  return q ? { robots: { index: false, follow: true } } : {}
+}
 
 const TIPO_LABEL: Record<string, string> = {
   ley: 'Ley', dl: 'Decreto Ley', dfl: 'DFL', dto: 'Decreto', cod: 'Código', res: 'Resolución',


### PR DESCRIPTION
## Problem

`app/buscar/page.tsx` has no `generateMetadata` / metadata override, so it inherits the root layout's default (indexable, no `robots` directive) — for every `?q=` value. Confirmed live: no `<meta name="robots">` and no `<link rel="canonical">` on `https://leyes.pisanvs.cl/buscar?q=arriendo`.

That means an effectively unbounded number of query-string variants of `/buscar` are indexable, over content whose real canonical page is the norma itself (`/norma/{id}/{slug}`). A `site:leyes.pisanvs.cl inurl:buscar` search today shows no evidence these are actually indexed yet, but there's no guard against it happening — and per the audit brief, unindexed-but-indexable parameterized search pages are one of the more common ways a site drags down its own average quality signal in Google's eyes.

## Fix

Added `generateMetadata` to `app/buscar/page.tsx`:
- `?q=` present (a results page) → `robots: { index: false, follow: true }`.
- No `q` (the bare `/buscar` entry page — a real, if thin, "search this corpus" page) → `{}`, i.e. default indexable behavior, unchanged.

## Verification

Run from `site/` with `DATABASE_URL` unset:

- `npx tsc --noEmit` — clean.
- `pnpm vitest run` — 68 passed, 1 skipped (unchanged).
- `pnpm build` — green, route table unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P44iMEnQPJwHTJWSuTvW3B

---
_Generated by [Claude Code](https://claude.ai/code/session_01P44iMEnQPJwHTJWSuTvW3B)_