### PR TITLE
seo: link /cambios from the persistent site nav

### DIFF
--- a/site/components/TopBar.tsx
+++ b/site/components/TopBar.tsx
@@ -103,6 +103,12 @@ export function TopBar({ crumb }: Props) {
             Guías
           </Link>
           <Link
+            href="/cambios"
+            className="px-2 py-1 rounded-md text-ink-soft hover:text-ink hover:bg-paper-sunk transition"
+          >
+            Cambios
+          </Link>
+          <Link
             href="/blog"
             className="px-2 py-1 rounded-md text-ink-soft hover:text-ink hover:bg-paper-sunk transition"
           >


### PR DESCRIPTION
## Problem

`/cambios` (the change-history hub — `qualifiesForCambios` gates ~5,390 normas onto it) is not reachable from on-site navigation anywhere. Checked:

- `components/TopBar.tsx` — links `/temas`, `/guia`, `/blog`; no `/cambios`.
- Homepage body — no `href="/cambios"`.
- `/guia` and `/temas` hub pages — no `href="/cambios"` either (verified via curl against the live pages).

It's only discoverable via `sitemap-contenido.xml`, or one law at a time via the "Qué cambió y cuándo →" link on that law's own `/guia/{law}` page (when it qualifies) — never via the hub/index page itself. An orphaned hub page like this crawls late and ranks poorly (per this audit's own checklist item on internal linking).

## Fix

Added a "Cambios" link next to "Guías" in the `TopBar` nav — same pattern as the existing Temas/Guías/Blog links.

## Verification

Run from `site/` with `DATABASE_URL` unset:

- `npx tsc --noEmit` — clean.
- `pnpm vitest run` — 68 passed, 1 skipped (unchanged).
- `pnpm build` — green, route table unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P44iMEnQPJwHTJWSuTvW3B

---
_Generated by [Claude Code](https://claude.ai/code/session_01P44iMEnQPJwHTJWSuTvW3B)_