### PR TITLE
seo: fix la/el gender agreement on /guia and /cambios for cod/dl/dfl/dto

### DIFF
--- a/site/app/cambios/[...rest]/page.tsx
+++ b/site/app/cambios/[...rest]/page.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/lib/norma'
 import {
   fechaLarga, getGuiaStats, normaLabel, qualifiesForCambios, qualifiesForGuia,
-  resolveSeoRoute, tipoLabel,
+  resolveSeoRoute, tipoArticle, tipoLabel,
 } from '@/lib/seo'
 
 interface Props { params: Promise<{ rest: string[] }> }
@@ -25,7 +25,7 @@ async function load(norma: Norma) {
 }
 
 function title(n: Norma): string {
-  return `Qué cambió la ${normaLabel(n)}: historial de modificaciones`
+  return `Qué cambió ${tipoArticle(n.tipo)} ${normaLabel(n)}: historial de modificaciones`
 }
 
 export async function generateMetadata({ params }: Props) {
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: Props) {
   if (!data) return {}
   const { norma: n, versions, modifiedBy } = data
   const t = title(n)
-  const d = `La ${normaLabel(n)} ha cambiado ${versions.length} veces desde su publicación, por ${modifiedBy.length} ${modifiedBy.length === 1 ? 'norma modificadora' : 'normas modificadoras'}. Cada versión, su causa y qué texto regía en cada fecha.`
+  const d = `${tipoArticle(n.tipo, true)} ${normaLabel(n)} ha cambiado ${versions.length} veces desde su publicación, por ${modifiedBy.length} ${modifiedBy.length === 1 ? 'norma modificadora' : 'normas modificadoras'}. Cada versión, su causa y qué texto regía en cada fecha.`
   return {
     title: t,
     description: d,
@@ -59,22 +59,23 @@ function causaFor(v: Version, modifiedBy: ModLink[]): ModLink | null {
 
 function buildFaq(n: Norma, versions: Version[], modifiedBy: ModLink[], fecha: string): FaqEntry[] {
   const label = normaLabel(n)
+  const art = tipoArticle(n.tipo)
   const first = versions[0]
   const latest = modifiedBy[0]
   const faq: FaqEntry[] = [
     {
-      q: `¿Cuántas veces ha cambiado la ${label}?`,
-      a: `El corpus registra ${versions.length} versiones del texto de la ${label}, desde la original del ${fechaLarga(first.desde)} hasta la vigente desde el ${fechaLarga(fecha)}. Los cambios provienen de ${modifiedBy.length} ${modifiedBy.length === 1 ? 'norma modificadora' : 'normas modificadoras'}.`,
+      q: `¿Cuántas veces ha cambiado ${art} ${label}?`,
+      a: `El corpus registra ${versions.length} versiones del texto de ${art} ${label}, desde la original del ${fechaLarga(first.desde)} hasta la vigente desde el ${fechaLarga(fecha)}. Los cambios provienen de ${modifiedBy.length} ${modifiedBy.length === 1 ? 'norma modificadora' : 'normas modificadoras'}.`,
     },
     {
-      q: `¿Cuál es la última modificación de la ${label}?`,
+      q: `¿Cuál es la última modificación de ${art} ${label}?`,
       a: latest
         ? `La modificación más reciente registrada es de ${tipoLabel(latest.tipo)} ${latest.numero}, con fecha ${fechaLarga(latest.fecha)}. El texto resultante rige desde el ${fechaLarga(fecha)}.`
         : `El texto vigente rige desde el ${fechaLarga(fecha)}.`,
     },
     {
-      q: `¿Cómo veo el texto de la ${label} que regía en una fecha determinada?`,
-      a: `Cada versión de la ${label} tiene su propia URL con la fecha desde la que rige, y el lector permite comparar dos versiones palabra por palabra para ver exactamente qué se agregó y qué se eliminó.`,
+      q: `¿Cómo veo el texto de ${art} ${label} que regía en una fecha determinada?`,
+      a: `Cada versión de ${art} ${label} tiene su propia URL con la fecha desde la que rige, y el lector permite comparar dos versiones palabra por palabra para ver exactamente qué se agregó y qué se eliminó.`,
     },
   ]
   return faq
@@ -91,6 +92,7 @@ export default async function Page({ params }: Props) {
   const { norma: n, versions, modifiedBy, fecha, hasGuia } = data
 
   const label = normaLabel(n)
+  const art = tipoArticle(n.tipo)
   const faq = buildFaq(n, versions, modifiedBy, fecha)
   // Newest first: "what changed" is a recency question.
   const timeline = [...versions].reverse()
@@ -122,13 +124,13 @@ export default async function Page({ params }: Props) {
           {tipoLabel(n.tipo)} · Nº {n.numero} · Historial
         </p>
         <h1 className="font-display text-3xl md:text-[2.7rem] leading-[1.08] tracking-tight text-balance">
-          Qué cambió la <span className="text-ruby">{label}</span>
+          Qué cambió {art} <span className="text-ruby">{label}</span>
         </h1>
         <p className="mt-4 font-display italic text-lg md:text-xl text-ink-soft text-balance">
           {n.titulo}
         </p>
         <p className="mt-6 text-ink-soft max-w-2xl text-[15px] leading-relaxed">
-          El texto de la {label} no es uno solo. Ha cambiado {versions.length} veces desde que
+          El texto de {art} {label} no es uno solo. Ha cambiado {versions.length} veces desde que
           se publicó el {fechaLarga(n.fechaPublicacion)}. Abajo, cada versión con la norma que
           la causó — y un enlace al diff palabra por palabra.
         </p>
@@ -139,7 +141,7 @@ export default async function Page({ params }: Props) {
               href={guiaHref(n)}
               className="inline-flex items-center gap-2 border border-ink/80 hover:border-ruby text-ink hover:text-ruby transition px-4 py-2.5 rounded-md text-sm"
             >
-              Qué dice la {label} →
+              Qué dice {art} {label} →
             </Link>
           )}
           <Link
@@ -214,7 +216,7 @@ export default async function Page({ params }: Props) {
         </section>
 
         <section className="mt-14 border-t border-rule pt-10">
-          <h2 className="font-display text-2xl mb-4">Normas que han modificado la {label}</h2>
+          <h2 className="font-display text-2xl mb-4">Normas que han modificado {art} {label}</h2>
           <ul className="divide-y divide-rule">
             {modifiedBy.map((m) => (
               <li key={`${m.tipo}-${m.numero}-${m.fecha}`}>

--- a/site/app/guia/[...rest]/page.tsx
+++ b/site/app/guia/[...rest]/page.tsx
@@ -7,8 +7,8 @@ import {
   type ModLink, type Norma, type Version,
 } from '@/lib/norma'
 import {
-  fechaLarga, getGuiaArticles, getGuiaStats, normaLabel,
-  qualifiesForCambios, qualifiesForGuia, resolveSeoRoute, tipoLabel,
+  agreeGender, fechaLarga, getGuiaArticles, getGuiaStats, normaLabel,
+  qualifiesForCambios, qualifiesForGuia, resolveSeoRoute, tipoArticle, tipoLabel,
 } from '@/lib/seo'
 import { ArticleBody } from '@/components/seo/Prose'
 
@@ -32,7 +32,7 @@ async function load(norma: Norma) {
 }
 
 function title(n: Norma): string {
-  return `Qué dice la ${normaLabel(n)}: resumen, artículos y versiones`
+  return `Qué dice ${tipoArticle(n.tipo)} ${normaLabel(n)}: resumen, artículos y versiones`
 }
 
 function description(n: Norma, versions: Version[]): string {
@@ -66,33 +66,35 @@ function buildFaq(
   n: Norma, versions: Version[], fecha: string, modifies: number, modifiedBy: number,
 ): FaqEntry[] {
   const label = normaLabel(n)
+  const art = tipoArticle(n.tipo)
+  const Art = tipoArticle(n.tipo, true)
   const faq: FaqEntry[] = [
     {
-      q: `¿Qué es la ${label}?`,
+      q: `¿Qué es ${art} ${label}?`,
       a: `${label} — «${n.titulo}». Fue publicada el ${fechaLarga(n.fechaPublicacion)}${n.organismo ? ` por ${n.organismo}` : ''}.`,
     },
     {
-      q: `¿Desde cuándo rige el texto actual de la ${label}?`,
+      q: `¿Desde cuándo rige el texto actual de ${art} ${label}?`,
       a: versions.length > 1
         ? `El texto que se muestra rige desde el ${fechaLarga(fecha)}. Es la última de ${versions.length} versiones registradas desde su publicación.`
         : `El corpus registra una sola versión, vigente desde el ${fechaLarga(fecha)}: el texto no ha cambiado desde entonces.`,
     },
     {
-      q: `¿La ${label} sigue vigente?`,
+      q: `¿${Art} ${label} sigue vigente?`,
       a: n.derogado
-        ? `No. La ${label} figura como derogada en el corpus. Su texto sigue disponible en la versión que estuvo vigente hasta su derogación.`
-        : `Sí. La ${label} no figura como derogada. La última versión registrada rige desde el ${fechaLarga(fecha)}.`,
+        ? `No. ${Art} ${label} figura como ${agreeGender(n.tipo, 'derogada')} en el corpus. Su texto sigue disponible en la versión que estuvo vigente hasta su derogación.`
+        : `Sí. ${Art} ${label} no figura como ${agreeGender(n.tipo, 'derogada')}. La última versión registrada rige desde el ${fechaLarga(fecha)}.`,
     },
   ]
   if (modifiedBy > 0) {
     faq.push({
-      q: `¿Cuántas veces se ha modificado la ${label}?`,
+      q: `¿Cuántas veces se ha modificado ${art} ${label}?`,
       a: `El corpus registra ${modifiedBy} ${modifiedBy === 1 ? 'norma que la ha modificado' : 'normas que la han modificado'}, que producen ${versions.length} ${versions.length === 1 ? 'versión' : 'versiones'} de su texto.`,
     })
   }
   if (modifies > 0) {
     faq.push({
-      q: `¿Qué otras normas modifica la ${label}?`,
+      q: `¿Qué otras normas modifica ${art} ${label}?`,
       a: `Modifica ${modifies} ${modifies === 1 ? 'cuerpo legal' : 'cuerpos legales'}. En una ley modificatoria el efecto real se lee en la norma modificada, no en su propio texto.`,
     })
   }
@@ -112,6 +114,7 @@ export default async function Page({ params }: Props) {
   const { norma: n, versions, fecha, articles, modifies, modifiedBy, stats } = data
 
   const label = normaLabel(n)
+  const art = tipoArticle(n.tipo)
   const readerHref = canonicalHref(n)
   const hasCambios = qualifiesForCambios(versions, modifiedBy.length)
   const faq = buildFaq(n, versions, fecha, modifies.length, modifiedBy.length)
@@ -141,7 +144,7 @@ export default async function Page({ params }: Props) {
           {tipoLabel(n.tipo)} · Nº {n.numero}
         </p>
         <h1 className="font-display text-3xl md:text-[2.7rem] leading-[1.08] tracking-tight text-balance">
-          Qué dice la <span className="text-ruby">{label}</span>
+          Qué dice {art} <span className="text-ruby">{label}</span>
         </h1>
         <p className="mt-4 font-display italic text-lg md:text-xl text-ink-soft text-balance">
           {n.titulo}
@@ -190,7 +193,7 @@ export default async function Page({ params }: Props) {
 
         {versions.length > 1 && (
           <section className="mt-14 border-t border-rule pt-10">
-            <h2 className="font-display text-2xl mb-2">Versiones de la {label}</h2>
+            <h2 className="font-display text-2xl mb-2">Versiones de {art} {label}</h2>
             <p className="text-[14px] text-ink-soft mb-5">
               Cada fecha es un texto distinto. El corpus guarda las {versions.length}, no sólo la vigente.
             </p>
@@ -252,10 +255,10 @@ export default async function Page({ params }: Props) {
         {(modifies.length > 0 || modifiedBy.length > 0) && (
           <section className="mt-14 border-t border-rule pt-10 grid md:grid-cols-2 gap-10">
             {modifies.length > 0 && (
-              <ModList title={`Qué modifica la ${label}`} items={modifies.slice(0, 12)} />
+              <ModList title={`Qué modifica ${art} ${label}`} items={modifies.slice(0, 12)} />
             )}
             {modifiedBy.length > 0 && (
-              <ModList title={`Qué ha modificado la ${label}`} items={modifiedBy.slice(0, 12)} />
+              <ModList title={`Qué ha modificado ${art} ${label}`} items={modifiedBy.slice(0, 12)} />
             )}
           </section>
         )}

--- a/site/lib/seo.test.ts
+++ b/site/lib/seo.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
-  fechaLarga, MIN_GUIA_ARTICLES, normaLabel, prettyNumero,
-  qualifiesForCambios, qualifiesForGuia, tipoLabel,
+  agreeGender, fechaLarga, MIN_GUIA_ARTICLES, normaLabel, prettyNumero,
+  qualifiesForCambios, qualifiesForGuia, tipoArticle, tipoLabel,
 } from './seo'
 import type { Norma, Version } from './norma'
 
@@ -74,6 +74,46 @@ describe('tipoLabel', () => {
 describe('normaLabel', () => {
   it('combines tipo label and dotted numero', () => {
     expect(normaLabel(LEY)).toBe('Ley 21.643')
+  })
+})
+
+describe('tipoArticle', () => {
+  // "la Ley 21.643" but "el Código Penal" / "el DFL 1" / "el Decreto 250" /
+  // "el Decreto Ley 3.500" — the regression this guards: every guía/cambios
+  // page for a cod/dl/dfl/dto used a hardcoded "la", which reads as broken
+  // Spanish ("la Código PENAL") in the page's own <title>, FAQ text and
+  // FAQPage JSON-LD.
+  it('uses the feminine article for ley-like tipos', () => {
+    expect(tipoArticle('ley')).toBe('la')
+    expect(tipoArticle('otras')).toBe('la')
+    expect(tipoArticle('res')).toBe('la')
+  })
+
+  it('uses the masculine article for código/decreto-like tipos', () => {
+    expect(tipoArticle('cod')).toBe('el')
+    expect(tipoArticle('dl')).toBe('el')
+    expect(tipoArticle('dfl')).toBe('el')
+    expect(tipoArticle('dto')).toBe('el')
+  })
+
+  it('capitalizes for sentence-initial use', () => {
+    expect(tipoArticle('cod', true)).toBe('El')
+    expect(tipoArticle('ley', true)).toBe('La')
+  })
+
+  it('defaults unknown tipos to feminine, matching prior behavior', () => {
+    expect(tipoArticle('bando')).toBe('la')
+  })
+})
+
+describe('agreeGender', () => {
+  it('keeps the feminine form for ley-like tipos', () => {
+    expect(agreeGender('ley', 'derogada')).toBe('derogada')
+  })
+
+  it('derives the masculine form for código/decreto-like tipos', () => {
+    expect(agreeGender('cod', 'derogada')).toBe('derogado')
+    expect(agreeGender('dfl', 'derogada')).toBe('derogado')
   })
 })
 

--- a/site/lib/seo.ts
+++ b/site/lib/seo.ts
@@ -213,6 +213,35 @@ export function tipoLabel(tipo: string): string {
   return TIPO_LABEL[tipo] ?? tipo.toUpperCase()
 }
 
+/** Grammatical gender of a tipo's Spanish label, for the definite article in
+ *  generated prose ("la Ley 21.643" vs "el Código Penal" vs "el DFL 1").
+ *  Missing tipos default to feminine — that was the effective behavior
+ *  everywhere before this map existed, so an unmapped tipo stays as it was. */
+const TIPO_GENDER: Record<string, 'f' | 'm'> = {
+  ley: 'f',
+  dl: 'm',
+  dfl: 'm',
+  dto: 'm',
+  cod: 'm',
+  res: 'f',
+  otras: 'f',
+}
+
+/** "el"/"la" for a tipo, e.g. `` `${tipoArticle(n.tipo)} ${normaLabel(n)}` ``
+ *  → "el Código Penal". Pass `capitalized` for sentence-initial use ("La Ley…"
+ *  vs "…de la Ley…"). */
+export function tipoArticle(tipo: string, capitalized = false): string {
+  const article = TIPO_GENDER[tipo] === 'm' ? 'el' : 'la'
+  return capitalized ? article[0].toUpperCase() + article.slice(1) : article
+}
+
+/** Agree an -o/-a adjective ending with a tipo's gender, e.g.
+ *  `agreeGender(n.tipo, 'derogada')` → "derogado" for a `cod`/`dl`/`dfl`/`dto`.
+ *  `feminine` must already end in "a"; only the masculine form is derived. */
+export function agreeGender(tipo: string, feminine: string): string {
+  return TIPO_GENDER[tipo] === 'm' ? `${feminine.slice(0, -1)}o` : feminine
+}
+
 /** "Ley 21.643" — Chileans write and search law numbers dotted. */
 export function prettyNumero(numero: string): string {
   if (!/^\d+$/.test(numero)) return numero


### PR DESCRIPTION
## Problem

`TIPO_LABEL` (`site/lib/seo.ts`) maps `cod` → "Código", `dl` → "Decreto Ley", `dfl` → "DFL", `dto` → "Decreto" — all grammatically masculine in Spanish — but every generated title, FAQ question/answer, JSON-LD `FAQPage` entry, and visible heading on `/guia/{law}` and `/cambios/{law}` hardcoded the feminine article "la" in front of the label.

Confirmed live on `/guia/1984/cod-penal-codigo-penal` (Código Penal) before this fix:

```html
<title>Qué dice la Código PENAL: resumen, artículos y versiones · LeyChile</title>
```
```json
{"@type":"FAQPage","mainEntity":[{"@type":"Question","name":"¿Qué es la Código PENAL?", ...
```

This is broken Spanish in the page's own `<title>` (what shows in Google search results and browser tabs), in visible body copy ("Qué dice la Código PENAL", "La Código PENAL figura como derogada"), and in the `FAQPage` JSON-LD Google may pull into a rich result — for every `cod`, `dl`, `dfl` and `dto` page that qualifies for `/guia` or `/cambios`. That set includes some of the highest-value pages on the site: Código Penal, Código Civil, Código del Trabajo, Código de Comercio, etc.

## Fix

- `lib/seo.ts`: added `TIPO_GENDER` (the same tipo set `TIPO_LABEL` already covers) plus:
  - `tipoArticle(tipo, capitalized?)` → `"el"`/`"la"`, with a capitalized form for sentence-initial use ("La Ley…" vs "…de la Ley…").
  - `agreeGender(tipo, feminineWord)` → derives the masculine `-o` form for masculine tipos, e.g. `agreeGender('cod', 'derogada')` → `'derogado'`.
  - Unmapped tipos default to feminine, matching the prior (undifferentiated) behavior — no regression for tipos outside this map.
- `app/guia/[...rest]/page.tsx`, `app/cambios/[...rest]/page.tsx`: replaced every hardcoded `la ${label}` / `La ${label}` / `derogada` in `title()`, `buildFaq()`, `generateMetadata()`'s description, and the JSX body with the gender-correct forms.
- `lib/seo.test.ts`: tests for `tipoArticle` and `agreeGender` across both genders, capitalization, and the unmapped-tipo fallback.

After the fix, the same page reads:

```html
<title>Qué dice el Código PENAL: resumen, artículos y versiones · LeyChile</title>
```
```json
{"@type":"FAQPage","mainEntity":[{"@type":"Question","name":"¿Qué es el Código PENAL?", ...
```

## Verification

Run from `site/` with `DATABASE_URL` unset, per this repo's requirement that the build never need Postgres:

- `npx tsc --noEmit` — clean.
- `pnpm vitest run` — 74 passed, 1 skipped (68 existing + 6 new).
- `pnpm build` — green, route table unchanged, no new warnings.
- Live `curl`/HTML inspection against production confirmed the bug on `/guia/1984/cod-penal-codigo-penal` before writing the fix (see quotes above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5MqRnckQra6cGqgdVWiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5MqRnckQra6cGqgdVWiu6)_