### PR TITLE
fix(site): escape stray markdown chars in raw legal text before ReactMarkdown

### DIFF
--- a/site/components/CleanReader.tsx
+++ b/site/components/CleanReader.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { useQuery } from '@tanstack/react-query'
 import { fetchRawText } from '@/lib/rawtext'
+import { escapeLegalMarkdown } from '@/lib/mdEscape'
 
 interface Props { sha: string; relDir: string }
 
@@ -26,7 +27,7 @@ export function CleanReader({ sha, relDir }: Props) {
           p:  ({ children }) => <p className="my-3">{children}</p>,
         }}
       >
-        {q.data}
+        {escapeLegalMarkdown(q.data ?? '')}
       </ReactMarkdown>
     </article>
   )

--- a/site/components/EfectosPanel.tsx
+++ b/site/components/EfectosPanel.tsx
@@ -7,6 +7,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { segment, wordDiff, joinDiffText, type Segment } from '@/lib/diff'
 import { canonicalHref } from '@/lib/href'
+import { escapeLegalMarkdown } from '@/lib/mdEscape'
 import type { Efecto, EfectoArticle } from '@/lib/efectos'
 
 const TIPO_LABEL: Record<string, string> = {
@@ -250,7 +251,7 @@ function ModifierArticle({ article }: { article: Segment }) {
         <h3 className="font-display text-lg font-semibold mb-2 text-ink">{heading}</h3>
       )}
       <div className="prose-reader leading-relaxed text-[15px] text-ink-soft">
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{article.body}</ReactMarkdown>
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{escapeLegalMarkdown(article.body)}</ReactMarkdown>
       </div>
     </article>
   )

--- a/site/components/RedlineReader.tsx
+++ b/site/components/RedlineReader.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { fetchRawText } from '@/lib/rawtext'
+import { escapeLegalMarkdown } from '@/lib/mdEscape'
 import { segment, align, wordDiff, joinDiffText, type Aligned } from '@/lib/diff'
 import { ArticleSegment } from '@/components/ArticleSegment'
 import { EfectosAligned } from '@/components/EfectosPanel'
@@ -113,7 +114,7 @@ function CleanView({
           monospace={monospace}
         >
           <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
-            {s.body}
+            {escapeLegalMarkdown(s.body)}
           </ReactMarkdown>
         </ArticleSegment>
       ))}
@@ -225,7 +226,7 @@ function SideBySidePane({ side, aligned }: { side: 'prev' | 'curr'; aligned: Ali
       <div className="border-l-2 border-rule pl-3 prose-reader opacity-70">
         {aligned.curr.rawHeading && <h3 className="font-display text-lg mb-1">{aligned.curr.rawHeading}</h3>}
         <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
-          {aligned.curr.body}
+          {escapeLegalMarkdown(aligned.curr.body)}
         </ReactMarkdown>
       </div>
     )
@@ -236,7 +237,7 @@ function SideBySidePane({ side, aligned }: { side: 'prev' | 'curr'; aligned: Ali
       <div className="border-l-4 border-moss bg-moss-soft/40 pl-3 py-1 prose-reader">
         {aligned.curr!.rawHeading && <h3 className="font-display text-lg mb-1 text-moss">{aligned.curr!.rawHeading}</h3>}
         <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
-          {aligned.curr!.body}
+          {escapeLegalMarkdown(aligned.curr!.body)}
         </ReactMarkdown>
       </div>
     )
@@ -247,7 +248,7 @@ function SideBySidePane({ side, aligned }: { side: 'prev' | 'curr'; aligned: Ali
       <div className="border-l-4 border-ruby bg-ruby-soft/40 pl-3 py-1 line-through opacity-70 prose-reader">
         {aligned.prev!.rawHeading && <h3 className="font-display text-lg mb-1 text-ruby">{aligned.prev!.rawHeading}</h3>}
         <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
-          {aligned.prev!.body}
+          {escapeLegalMarkdown(aligned.prev!.body)}
         </ReactMarkdown>
       </div>
     )
@@ -392,7 +393,7 @@ function RedlineSegment({
       >
         <ins className="bg-moss-soft border-b-2 border-moss px-1 py-0.5 inline-block">
           <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
-            {aligned.curr.body}
+            {escapeLegalMarkdown(aligned.curr.body)}
           </ReactMarkdown>
         </ins>
       </ArticleSegment>
@@ -409,7 +410,7 @@ function RedlineSegment({
       >
         <del className="bg-ruby-soft px-1 py-0.5 inline-block">
           <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
-            {aligned.prev.body}
+            {escapeLegalMarkdown(aligned.prev.body)}
           </ReactMarkdown>
         </del>
       </ArticleSegment>
@@ -425,7 +426,7 @@ function RedlineSegment({
         monospace={monospace}
       >
         <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
-          {aligned.curr.body}
+          {escapeLegalMarkdown(aligned.curr.body)}
         </ReactMarkdown>
       </ArticleSegment>
     )

--- a/site/lib/mdEscape.test.ts
+++ b/site/lib/mdEscape.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { escapeLegalMarkdown } from './mdEscape'
+import ReactMarkdown from 'react-markdown'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+/** Regression fixture: idNorma 1077207 (CIRCULAR BANCOS N° 2.409), the norma
+ *  that surfaced this bug — a multiplication formula whose bare `*` paired
+ *  with an unrelated later `*` and ran emphasis across everything between
+ *  them. */
+const FORMULA_LINE = 'P = (IP / PE + IT) * 100'
+const FOOTNOTE_LINE = 'Estatutos de la sociedad.(*)'
+const BULLET_LINE = '* Ver instrucciones en hoja 2 de este Anexo'
+
+describe('escapeLegalMarkdown', () => {
+  it('escapes a lone multiplication asterisk', () => {
+    expect(escapeLegalMarkdown(FORMULA_LINE)).toBe('P = (IP / PE + IT) \\* 100')
+  })
+
+  it('escapes a footnote-marker asterisk', () => {
+    expect(escapeLegalMarkdown(FOOTNOTE_LINE)).toBe('Estatutos de la sociedad.(\\*)')
+  })
+
+  it('escapes a literal bullet so it does not become a list item', () => {
+    expect(escapeLegalMarkdown(BULLET_LINE)).toBe('\\* Ver instrucciones en hoja 2 de este Anexo')
+  })
+
+  it('leaves a genuine ATX heading untouched', () => {
+    expect(escapeLegalMarkdown('#### Artículo 41')).toBe('#### Artículo 41')
+    expect(escapeLegalMarkdown('## Capítulo 1-1')).toBe('## Capítulo 1-1')
+  })
+
+  it('escapes a stray # that is not a heading (mid-line)', () => {
+    expect(escapeLegalMarkdown('el N° 1 del artículo #80')).toBe('el N° 1 del artículo \\#80')
+  })
+
+  it('escapes underscores, tildes, backticks, brackets, and pipes', () => {
+    expect(escapeLegalMarkdown('a_b ~c~ `d` [e] f|g'))
+      .toBe('a\\_b \\~c\\~ \\`d\\` \\[e\\] f\\|g')
+  })
+
+  it('round-trips through ReactMarkdown back to the original plain text', () => {
+    const paragraph = [FORMULA_LINE, '', FOOTNOTE_LINE, '', BULLET_LINE].join('\n')
+    const html = renderToStaticMarkup(
+      ReactMarkdown({ children: escapeLegalMarkdown(paragraph) }) as any,
+    )
+    // No emphasis, no list — the formula's "*" must not have opened an
+    // <em> that swallows everything up to the bullet line's "*".
+    expect(html).not.toMatch(/<em>/)
+    expect(html).not.toMatch(/<li>/)
+    expect(html).toContain('P = (IP / PE + IT) * 100')
+    expect(html).toContain('Estatutos de la sociedad.(*)')
+    expect(html).toContain('* Ver instrucciones en hoja 2 de este Anexo')
+  })
+})

--- a/site/lib/mdEscape.ts
+++ b/site/lib/mdEscape.ts
@@ -1,0 +1,28 @@
+/** Escape markdown-significant characters in raw legal text before it goes
+ *  through ReactMarkdown.
+ *
+ *  The corpus is government legal/administrative text, not authored
+ *  markdown — but it routinely contains characters that ARE markdown
+ *  syntax by coincidence: footnote markers ("(*)"), plain-text bullets
+ *  ("* Ver instrucciones..."), and — worst — multiplication in formulas
+ *  ("P = (IP / PE + IT) * 100", common in banking/financial circulars).
+ *  A single unpaired `*` doesn't just misrender locally: CommonMark pairs
+ *  it with the NEXT `*`-like delimiter anywhere later in the same block,
+ *  which can italicize everything in between — sometimes thousands of
+ *  characters, across paragraphs.
+ *
+ *  The one markdown syntax the pipeline itself intentionally emits into
+ *  this text is the "#### " article-heading prefix (see CLAUDE.md's
+ *  `_MD_HEADING_RE` note) — genuine ATX headings at the start of a line are
+ *  left alone. Every other occurrence of a markdown-special character is
+ *  escaped, since none of it is ever intentional in source legal text.
+ */
+const HEADING_START = /^\s{0,3}#{1,6} /
+const INLINE_SPECIAL = /[`*_~[\]<|#]/g
+
+export function escapeLegalMarkdown(text: string): string {
+  return text
+    .split('\n')
+    .map(line => (HEADING_START.test(line) ? line : line.replace(INLINE_SPECIAL, '\\$&')))
+    .join('\n')
+}


### PR DESCRIPTION
## Problem

Reported live: https://leyes.pisanvs.cl/norma/1077207/cir-bancos-2409-recopilacion-actualizada-de-normas/2022-12-01 — formatting/parsing looked off.

Article bodies are raw BCN legal/administrative text, not authored markdown, but they routinely contain characters that happen to be markdown syntax:

- footnote markers: `Estatutos de la sociedad.(*)`
- plain bullets: `* Ver instrucciones en hoja 2 de este Anexo`
- multiplication in formulas (this circular is full of them): `P = (IP / PE + IT) * 100`

A single unpaired `*` doesn't just misrender locally — CommonMark pairs it with the *next* `*`-like delimiter anywhere later in the block, which can silently italicize everything in between, sometimes thousands of characters across paragraphs. Confirmed via `curl`: this norma's raw text (2.2MB) has 18+ unpaired single-`*` occurrences.

## Fix

`site/lib/mdEscape.ts` (`escapeLegalMarkdown`) escapes markdown-significant characters (` `*_~[]<|#`) in raw body text before it reaches `ReactMarkdown`, applied at every render site that shows raw legal text:

- `RedlineReader.tsx` (all 7 `ReactMarkdown` call sites — unchanged/added/removed segment views)
- `CleanReader.tsx`
- `EfectosPanel.tsx`

Genuine ATX headings (`#### Artículo 41`, the one markdown syntax the pipeline itself intentionally emits — see CLAUDE.md's `_MD_HEADING_RE` note) are preserved untouched.

**Does not touch stored/canonical text.** This is render-layer only — the git-committed `historial` source of truth and `canonical_sha256` validation gate are unaffected.

**Word-level diff rendering is untouched and unaffected**: `wordDiff`/`joinDiffText` output renders as plain `<span>`/`<ins>`/`<del>` React elements, never through `ReactMarkdown` — verified by reading the code before making this change.

## Verification

```
$ cd site && unset DATABASE_URL
$ npx tsc --noEmit        # clean (2 pre-existing unrelated satori/@resvg errors, not touched by this PR)
$ pnpm vitest run         # 148 passed, 2 skipped
$ pnpm build              # green
```

New `lib/mdEscape.test.ts` (7 tests) includes:
- the exact formula/footnote/bullet lines from idNorma=1077207 as regression fixtures
- a round-trip test through actual `ReactMarkdown` (`renderToStaticMarkup`) asserting the fixture text produces no `<em>` and no `<li>`
- heading preservation (`#### `/`## ` untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)