### PR TITLE
seo: set top-level meta description on norma pages

### DIFF
--- a/site/app/norma/[id]/[[...rest]]/page.tsx
+++ b/site/app/norma/[id]/[[...rest]]/page.tsx
@@ -70,6 +70,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     `Publicada el ${fechaLarga(norma.fechaPublicacion)}. Texto completo, historial de versiones y modificaciones.`
   return {
     title,
+    description,
     openGraph: {
       title,
       description,


### PR DESCRIPTION
## Problem

`generateMetadata()` for the canonical `/norma/{id}/{slug}` route — the primary page type for the entire corpus, ~333k pages — only set `description` inside `openGraph`, never at the top level of the returned `Metadata` object:

```ts
return {
  title,
  openGraph: {
    title,
    description,   // only here
    images: [...],
  },
  alternates: { canonical: `${SITE}${canonical}` },
}
```

Next.js falls back to the root layout's generic sitewide `description` for `<meta name="description">` whenever a page doesn't set its own. So the actual Google search-result snippet for every norma page was the generic homepage blurb ("Control de cambios para toda la historia de la ley chilena…") instead of the per-law description already being computed right there in the function.

Confirmed live on production:

```
$ curl -s https://leyes.pisanvs.cl/norma/1/acd-1-acuerda-las-caracteristicas-de-las-categorias-y-los | grep -oE '<meta name="description"[^>]*>|<meta property="og:description"[^>]*>'
<meta name="description" content="Control de cambios para toda la historia de la ley chilena: cada ley, decreto y resolución desde 1810, reconstruida como un repositorio git. Para agentes y humanos."/>
<meta property="og:description" content="ACD 1 — COMISIÓN CLASIFICADORA DE RIESGO. Publicada el 13 de mayo de 1991. Texto completo, historial de versiones y modificaciones."/>
```

`og:description` carries the correct per-law text; `<meta name="description">` — the one Google actually uses for the search snippet — does not.

Every sibling page type already sets both fields from the same string (`site/app/guia/[...rest]/page.tsx`, `cambios/[...rest]/page.tsx`, `temas/[slug]/page.tsx`, `blog/[slug]/page.tsx`) — the norma route was the one deviation from that pattern.

## Fix

Add the missing top-level `description` field alongside the existing `openGraph.description`, matching the convention used everywhere else in `site/app`.

## Verification

Run from `site/`, with no `DATABASE_URL` set (matches how this image actually builds):

```
$ pnpm build
✓ Compiled successfully in 15.7s
✓ Completed runAfterProductionCompile in 278ms
✓ Finished TypeScript in 7.7s
✓ Generating static pages using 3 workers (50/50)
...
├ ƒ /norma/[id]/[[...rest]]
...

$ npx tsc --noEmit
(clean, no output)

$ pnpm vitest run
 Test Files  12 passed | 1 skipped (13)
      Tests  84 passed | 1 skipped (85)
```

One-line change, no behavioral change to routing/rendering — only the metadata object gains the field every other page type already sets.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgDVSyr4wme88F7gzUzJEz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgDVSyr4wme88F7gzUzJEz)_