### PR TITLE
seo: fix per-page Open Graph/Twitter fields lost to layout.tsx's shallow metadata merge

### DIFF
--- a/site/app/blog/[slug]/page.tsx
+++ b/site/app/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { articleJsonLd, breadcrumbJsonLd, jsonLdScript, SITE } from '@/lib/jsonld'
+import { SITE_NAME, OG_LOCALE } from '@/lib/site'
 import { getPost, listPosts, POSTS } from '@/lib/blog'
 import { fechaLarga } from '@/lib/seo'
 
@@ -20,6 +21,8 @@ export async function generateMetadata({ params }: Props) {
     alternates: { canonical: `${SITE}/blog/${post.slug}` },
     openGraph: {
       type: 'article',
+      siteName: SITE_NAME,
+      locale: OG_LOCALE,
       title: post.title,
       description: post.description,
       publishedTime: post.published,

--- a/site/app/cambios/[...rest]/page.tsx
+++ b/site/app/cambios/[...rest]/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { notFound, permanentRedirect } from 'next/navigation'
 import { breadcrumbJsonLd, faqJsonLd, jsonLdScript, legislationJsonLd, SITE, type FaqEntry } from '@/lib/jsonld'
+import { SITE_NAME, OG_LOCALE } from '@/lib/site'
 import { cambiosHref, canonicalHref, guiaHref } from '@/lib/href'
 import {
   currentFecha, getModifiedBy, getVersions, type ModLink, type Norma, type Version,
@@ -41,6 +42,9 @@ export async function generateMetadata({ params }: Props) {
     title: t,
     description: d,
     openGraph: {
+      type: 'website',
+      siteName: SITE_NAME,
+      locale: OG_LOCALE,
       title: t,
       description: d,
       images: [{ url: `/api/og?id=${n.idNorma}`, width: 1200, height: 630 }],

--- a/site/app/guia/[...rest]/page.tsx
+++ b/site/app/guia/[...rest]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, permanentRedirect } from 'next/navigation'
 import {
   breadcrumbJsonLd, cleanTitulo, faqJsonLd, jsonLdScript, legislationJsonLd, SITE, type FaqEntry,
 } from '@/lib/jsonld'
+import { SITE_NAME, OG_LOCALE } from '@/lib/site'
 import { cambiosHref, canonicalHref, guiaHref } from '@/lib/href'
 import {
   currentFecha, getModifiedBy, getModifies, getVersions,
@@ -54,6 +55,9 @@ export async function generateMetadata({ params }: Props) {
     title: t,
     description: d,
     openGraph: {
+      type: 'website',
+      siteName: SITE_NAME,
+      locale: OG_LOCALE,
       title: t,
       description: d,
       images: [{ url: `/api/og?id=${data.norma.idNorma}`, width: 1200, height: 630 }],

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -28,10 +28,17 @@ export const metadata: Metadata = {
     title: OG_TITLE,
     description: DESCRIPTION,
   },
+  // No title/description here: Next.js auto-fills unset twitter fields from
+  // openGraph (see resolve-metadata.js's postProcessMetadata) — but only
+  // when the *merged* twitter object has no title/description at all. If we
+  // set them here, every route that defines its own per-page openGraph
+  // (norma, guia, cambios, temas, blog — everywhere but this generic
+  // fallback) inherits this literal object unchanged instead, since none of
+  // them define their own `twitter` field. That silently pinned the Twitter
+  // Card preview to the sitewide homepage blurb on every page, while
+  // og:title/og:description were correctly per-page all along.
   twitter: {
     card: 'summary_large_image',
-    title: OG_TITLE,
-    description: DESCRIPTION,
   },
 }
 

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -2,7 +2,7 @@ import './globals.css'
 import type { Metadata } from 'next'
 import { AppShell } from '@/components/AppShell'
 import { SiteAlert } from '@/components/SiteAlert'
-import { SITE } from '@/lib/site'
+import { SITE, SITE_NAME, OG_LOCALE } from '@/lib/site'
 
 // Aligned to the landing hero copy. Reused across the base metadata, OG, and
 // Twitter so they never drift. The og:image is app/opengraph-image.png, which
@@ -19,11 +19,11 @@ export const metadata: Metadata = {
     template: '%s · LeyChile',
   },
   description: DESCRIPTION,
-  applicationName: 'LeyChile',
+  applicationName: SITE_NAME,
   openGraph: {
     type: 'website',
-    siteName: 'LeyChile',
-    locale: 'es_CL',
+    siteName: SITE_NAME,
+    locale: OG_LOCALE,
     url: SITE,
     title: OG_TITLE,
     description: DESCRIPTION,

--- a/site/app/norma/[id]/[[...rest]]/page.tsx
+++ b/site/app/norma/[id]/[[...rest]]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { notFound, permanentRedirect } from 'next/navigation'
 import { cleanTitulo, SITE } from '@/lib/jsonld'
+import { SITE_NAME, OG_LOCALE } from '@/lib/site'
 import {
   canonicalPath, getAvisos, getCanonicalNorma, getKeySiblings, getNormaById,
   getRefundido, getVersions,
@@ -71,6 +72,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title,
     openGraph: {
+      type: 'website',
+      siteName: SITE_NAME,
+      locale: OG_LOCALE,
       title,
       description,
       images: [{ url: `/api/og?id=${norma.idNorma}`, width: 1200, height: 630 }],

--- a/site/lib/site.ts
+++ b/site/lib/site.ts
@@ -14,6 +14,23 @@ export const SITE = (process.env.SITE_URL ?? 'https://leyes.pisanvs.cl').replace
 /** The remote MCP endpoint. Agents connect here; see /llms.txt. */
 export const MCP_PATH = '/api/mcp'
 
+/**
+ * Open Graph siteName/locale, shared by every page that sets its own
+ * `openGraph` object.
+ *
+ * Next.js's metadata merge is shallow per top-level key: a page that defines
+ * `openGraph` replaces the root layout's whole object rather than merging
+ * into it (see `mergeMetadata` in next/dist/lib/metadata/resolve-metadata.js
+ * — each case just overwrites `newResolvedMetadata[key]` with the result of
+ * resolving *that segment's own* value). So `app/layout.tsx` setting
+ * `openGraph.siteName`/`locale` only reaches routes that don't override
+ * `openGraph` at all (currently just `/temas/[slug]` and the homepage) —
+ * every route with a per-page `openGraph` (norma, guia, cambios, blog) has
+ * to repeat these explicitly or lose them.
+ */
+export const SITE_NAME = 'LeyChile'
+export const OG_LOCALE = 'es_CL'
+
 /** The public repo. Branch `historial` holds one commit per publication.
  *
  *  For humans and for anyone cloning the corpus. Don't hand GitHub URLs to


### PR DESCRIPTION
Two related fixes to the same root cause: Next.js's metadata merge is shallow per top-level key, so any route that defines its own `openGraph` (norma/guia/cambios/blog) fully replaces the root layout's `openGraph` object instead of merging into it — silently dropping whatever the root layout set that the page doesn't repeat.

## Commit 1 — Twitter Card title/description pinned to the homepage blurb

`app/layout.tsx`'s root `metadata.twitter` set literal `title`/`description` (the homepage strings). No page under `app/` sets its own `twitter` field, so that literal object carried through unchanged to every page. Confirmed live:

```
$ curl -s https://leyes.pisanvs.cl/norma/1/acd-1-... | grep twitter:
<meta name="twitter:title" content="El corpus jurídico chileno, en formato amigable"/>
<meta name="twitter:description" content="Control de cambios para toda la historia..."/>
```

...while `og:title`/`og:description` were correctly per-page. Fix: drop `title`/`description` from the root layout's `twitter` object (keep `card`). Next.js auto-fills unset twitter fields from `openGraph` — but only when the field is absent entirely, which is why `twitter:image` was already correct (root layout never set an image) while title/description weren't.

## Commit 2 — og:site_name / og:locale missing on norma, guia, cambios, blog

Same shallow-merge mechanism, different fields: every route that sets its own `openGraph` (to get its per-page title/description/image) drops `siteName`/`locale` from the root layout since it doesn't repeat them. Confirmed live — present on `/` and `/temas/[slug]` (which don't override `openGraph`), absent everywhere else:

```
$ curl -s https://leyes.pisanvs.cl/norma/1/... | grep -oE 'og:(site_name|locale)'
(nothing)
```

Fix: added `SITE_NAME`/`OG_LOCALE` constants to `lib/site.ts` and set them in the `openGraph` block of the four routes that override it.

## Verification

Run from `site/`, with no `DATABASE_URL` set (matches how this image actually builds), after both commits:

```
$ pnpm build
✓ Compiled successfully
✓ Finished TypeScript
✓ Generating static pages using 3 workers (50/50)

$ npx tsc --noEmit
(clean, no output)

$ pnpm vitest run
 Test Files  13 passed | 1 skipped (14)
      Tests  92 passed | 1 skipped (93)
```

Traced the actual merge/fallback logic in `node_modules/next/dist/lib/metadata/resolve-metadata.js` (`mergeMetadata`, `postProcessMetadata`) and `resolve-opengraph.js` (`resolveTwitter`) before relying on it. Both changes are purely additive/subtractive metadata fields — no routing, rendering, or canonical-tag changes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jo5MqbMzw1WqH3DioJCoSb