### PR TITLE
Public REST API at /v1 — API-key auth, per-key usage, eight endpoints

### DIFF
--- a/docs/superpowers/plans/2026-09-08-public-api.md
+++ b/docs/superpowers/plans/2026-09-08-public-api.md
@@ -1,0 +1,1662 @@
+# Public REST API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a read-only, API-key-authenticated JSON API at `/v1` covering the same ground as the MCP server, with per-key usage recorded for observability.
+
+**Architecture:** Next.js route handlers under `site/app/api/v1/` call the existing `@/lib/norma` and `@/lib/search` functions directly — the same data layer the MCP server uses, with JSON rather than prose as the presentation. A single `withApiKey()` wrapper handles authentication, timing, the error envelope, and usage recording, so no route handler repeats that logic.
+
+**Tech Stack:** Next.js 16 route handlers, TypeScript 5.x, `pg`, Postgres 16 with `pgcrypto`, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-09-08-public-api-design.md`
+
+## Global Constraints
+
+- All endpoints are `GET` and read-only. No writes, ever.
+- `site/` pins `typescript` to **5.x**. Never `pnpm add -D typescript` unpinned — it floats to the 7.0 `tsgo` preview and breaks Next 16's build checker.
+- Run `pnpm` from inside `site/` (its `package.json` declares `packageManager: pnpm@9.15.0`).
+- Verify with `cd site && pnpm vitest run && pnpm tsc --noEmit`.
+- Commits are GPG-signed but this shell has no TTY; use `--no-gpg-sign`.
+- `api_usage.endpoint` stores the **route template**, never a concrete path. This is a privacy guarantee, not a convention.
+- A database failure returns **503**, never 200 with an empty list.
+- Field names use the domain's Spanish (`titulo`, `numero`, `articulos`, `vigencia`).
+- `idNorma` addresses every norma. `(tipo, numero)` is not unique.
+- Local Postgres for SQL verification: `docker start leychile-verify` (port 55432, already loaded).
+
+---
+
+### Task 1: Schema, key issuance, and usage pruning
+
+**Files:**
+- Create: `sql/006_api.sql`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: tables `api_key(id, key_hash, key_prefix, label, created_at, revoked_at)` and `api_usage(id, key_id, ts, endpoint, status, duration_ms)`; functions `issue_api_key(text) -> text`, `revoke_api_key(text) -> boolean`, `prune_api_usage(int) -> bigint`.
+
+- [ ] **Step 1: Write the migration**
+
+Create `sql/006_api.sql`:
+
+```sql
+-- Public REST API: keys and usage.
+--
+-- Keys are stored as SHA-256 digests. The plaintext is returned once by
+-- issue_api_key and is unrecoverable afterwards, so a database leak yields no
+-- usable credentials.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS api_key (
+  id         bigserial PRIMARY KEY,
+  key_hash   text NOT NULL UNIQUE,
+  -- Display only, so a human can tell keys apart in a listing. Never
+  -- sufficient to authenticate with.
+  key_prefix text NOT NULL,
+  label      text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  revoked_at timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS api_usage (
+  id          bigserial PRIMARY KEY,
+  key_id      bigint NOT NULL REFERENCES api_key (id) ON DELETE CASCADE,
+  ts          timestamptz NOT NULL DEFAULT now(),
+  -- The route TEMPLATE ('/v1/normas/{idNorma}'), never the concrete path.
+  -- Storing '/v1/normas/29994' would build a per-caller record of which laws
+  -- someone read — the same category of data as the query text this design
+  -- deliberately does not keep.
+  endpoint    text NOT NULL,
+  status      int NOT NULL,
+  duration_ms int NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS api_usage_key_ts_idx ON api_usage (key_id, ts DESC);
+CREATE INDEX IF NOT EXISTS api_usage_ts_idx     ON api_usage (ts);
+
+-- Returns the plaintext key ONCE. There is no way to recover it later.
+CREATE OR REPLACE FUNCTION issue_api_key(p_label text)
+RETURNS text LANGUAGE plpgsql AS $$
+DECLARE
+  raw   text;
+  token text;
+BEGIN
+  IF p_label IS NULL OR btrim(p_label) = '' THEN
+    RAISE EXCEPTION 'label is required';
+  END IF;
+  -- 24 bytes of CSPRNG, base64url. translate() strips the base64 characters
+  -- that are unsafe in a URL or an Authorization header.
+  raw   := translate(encode(gen_random_bytes(24), 'base64'), '+/=', '-_');
+  token := 'lc_live_' || raw;
+  INSERT INTO api_key (key_hash, key_prefix, label)
+  VALUES (encode(digest(token, 'sha256'), 'hex'), left(token, 16), btrim(p_label));
+  RETURN token;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION revoke_api_key(p_prefix text)
+RETURNS boolean LANGUAGE plpgsql AS $$
+DECLARE n int;
+BEGIN
+  UPDATE api_key SET revoked_at = now()
+   WHERE key_prefix = p_prefix AND revoked_at IS NULL;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RETURN n > 0;
+END
+$$;
+
+-- Mirrors the 90-day prune retier.py already applies to analytics.event.
+CREATE OR REPLACE FUNCTION prune_api_usage(p_days int DEFAULT 90)
+RETURNS bigint LANGUAGE plpgsql AS $$
+DECLARE n bigint;
+BEGIN
+  DELETE FROM api_usage WHERE ts < now() - make_interval(days => p_days);
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RETURN n;
+END
+$$;
+```
+
+- [ ] **Step 2: Apply it to the local Postgres and verify**
+
+```bash
+docker start leychile-verify
+cd /home/pisanvs/code/ley-chile/.worktrees/public-api
+docker cp sql/006_api.sql leychile-verify:/tmp/006.sql
+docker exec leychile-verify psql -U postgres -v ON_ERROR_STOP=1 -f /tmp/006.sql
+```
+
+Expected: `CREATE EXTENSION`, `CREATE TABLE` ×2, `CREATE INDEX` ×2, `CREATE FUNCTION` ×3, no errors.
+
+- [ ] **Step 3: Verify issuance, hashing, revocation and pruning behave**
+
+```bash
+docker exec -i leychile-verify psql -U postgres <<'SQL'
+SELECT issue_api_key('Acme Corp') AS plaintext_shown_once \gset
+SELECT :'plaintext_shown_once' LIKE 'lc_live_%' AS has_prefix,
+       length(:'plaintext_shown_once') AS len;
+-- the plaintext must NOT be recoverable from the table
+SELECT count(*) AS leaked FROM api_key
+ WHERE key_hash = :'plaintext_shown_once' OR key_prefix = :'plaintext_shown_once';
+-- the stored hash must match sha256 of the plaintext
+SELECT key_hash = encode(digest(:'plaintext_shown_once','sha256'),'hex') AS hash_matches,
+       key_prefix, label FROM api_key;
+SELECT revoke_api_key((SELECT key_prefix FROM api_key)) AS revoked_first_time;
+SELECT revoke_api_key((SELECT key_prefix FROM api_key)) AS revoked_again_is_false;
+SELECT prune_api_usage(90) AS pruned_rows;
+SQL
+```
+
+Expected: `has_prefix = t`, `len = 40`, `leaked = 0`, `hash_matches = t`, `revoked_first_time = t`, `revoked_again_is_false = f`, `pruned_rows = 0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sql/006_api.sql
+git commit --no-gpg-sign -m "feat(api): api_key and api_usage schema with key issuance
+
+Keys are stored as SHA-256 digests; issue_api_key returns the plaintext
+once and it is unrecoverable afterwards, so a database leak yields no
+usable credentials. api_usage.endpoint holds the route template rather
+than the concrete path, so the log cannot become a record of which laws
+a given caller read. prune_api_usage mirrors the 90-day retention
+retier.py already applies to analytics.event."
+```
+
+---
+
+### Task 2: Key verification
+
+**Files:**
+- Create: `site/lib/apikey.ts`
+- Test: `site/lib/apikey.test.ts`
+
+**Interfaces:**
+- Consumes: `pool` from `@/lib/db`; `api_key` table from Task 1.
+- Produces: `verifyApiKey(token: string): Promise<ApiKeyRecord | null>` and `interface ApiKeyRecord { id: number; label: string }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `site/lib/apikey.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const query = vi.fn()
+vi.mock('./db', () => ({ pool: { query } }))
+
+beforeEach(() => {
+  vi.resetModules()
+  query.mockReset()
+})
+
+const ROW = { id: 7, label: 'Acme Corp' }
+
+describe('verifyApiKey', () => {
+  it('accepts a live key and returns its identity', async () => {
+    query.mockResolvedValue({ rows: [ROW] })
+    const { verifyApiKey } = await import('./apikey')
+    expect(await verifyApiKey('lc_live_abc')).toEqual(ROW)
+  })
+
+  it('looks the key up by SHA-256 digest, never by the plaintext', async () => {
+    // The plaintext must not appear in any query parameter — a query log or an
+    // error trace would otherwise leak usable credentials.
+    query.mockResolvedValue({ rows: [ROW] })
+    const { verifyApiKey } = await import('./apikey')
+    await verifyApiKey('lc_live_abc')
+    const params = query.mock.calls[0][1] as string[]
+    expect(params).toHaveLength(1)
+    expect(params[0]).not.toContain('lc_live_abc')
+    expect(params[0]).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('rejects an unknown key', async () => {
+    query.mockResolvedValue({ rows: [] })
+    const { verifyApiKey } = await import('./apikey')
+    expect(await verifyApiKey('lc_live_nope')).toBeNull()
+  })
+
+  it('rejects an empty token without touching the database', async () => {
+    const { verifyApiKey } = await import('./apikey')
+    expect(await verifyApiKey('')).toBeNull()
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('filters revoked keys in SQL rather than in the caller', async () => {
+    query.mockResolvedValue({ rows: [] })
+    const { verifyApiKey } = await import('./apikey')
+    await verifyApiKey('lc_live_abc')
+    expect(String(query.mock.calls[0][0])).toMatch(/revoked_at IS NULL/)
+  })
+})
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd site && pnpm vitest run lib/apikey.test.ts`
+Expected: FAIL — `Cannot find module './apikey'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `site/lib/apikey.ts`:
+
+```ts
+import { createHash } from 'node:crypto'
+import { pool } from './db'
+
+export interface ApiKeyRecord {
+  id: number
+  label: string
+}
+
+/** Verify a bearer token against `api_key`.
+ *
+ *  Only the SHA-256 digest is ever sent to the database, so the plaintext
+ *  cannot leak through a query log or an error trace. The digest is the unique
+ *  key, making this one indexed probe with no scan — and no string-comparison
+ *  timing channel, since an attacker cannot produce the digest without already
+ *  holding the token.
+ *
+ *  Revocation is filtered in SQL: a caller that forgets to check a flag is a
+ *  security bug, so there is no flag to forget. */
+export async function verifyApiKey(token: string): Promise<ApiKeyRecord | null> {
+  if (!token) return null
+  const hash = createHash('sha256').update(token).digest('hex')
+  const { rows } = await pool.query(
+    `SELECT id, label FROM api_key WHERE key_hash = $1 AND revoked_at IS NULL`,
+    [hash],
+  )
+  return rows.length ? { id: rows[0].id as number, label: rows[0].label as string } : null
+}
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `cd site && pnpm vitest run lib/apikey.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add site/lib/apikey.ts site/lib/apikey.test.ts
+git commit --no-gpg-sign -m "feat(api): verify bearer tokens against api_key
+
+Only the SHA-256 digest reaches the database, so the plaintext cannot
+leak through a query log or an error trace, and the lookup is one
+indexed probe. Revocation is filtered in SQL rather than returned for
+the caller to check — a flag a caller can forget is a security bug."
+```
+
+---
+
+### Task 3: Usage recording
+
+**Files:**
+- Create: `site/lib/apiusage.ts`
+- Test: `site/lib/apiusage.test.ts`
+
+**Interfaces:**
+- Consumes: `pool` from `@/lib/db`; `api_usage` table from Task 1.
+- Produces: `recordUsage(keyId: number, endpoint: string, status: number, durationMs: number): Promise<void>` — never rejects.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `site/lib/apiusage.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const query = vi.fn()
+vi.mock('./db', () => ({ pool: { query } }))
+
+beforeEach(() => {
+  vi.resetModules()
+  query.mockReset()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('recordUsage', () => {
+  it('writes one row with the key, endpoint, status and duration', async () => {
+    query.mockResolvedValue({ rows: [] })
+    const { recordUsage } = await import('./apiusage')
+    await recordUsage(7, '/v1/normas/{idNorma}', 200, 42)
+    expect(query.mock.calls[0][1]).toEqual([7, '/v1/normas/{idNorma}', 200, 42])
+  })
+
+  it('never rejects when the insert fails', async () => {
+    // Usage recording is observability. It must not be able to fail a request
+    // that already produced a correct response.
+    query.mockRejectedValue(new Error('deadlock detected'))
+    const { recordUsage } = await import('./apiusage')
+    await expect(recordUsage(7, '/v1/search', 200, 5)).resolves.toBeUndefined()
+  })
+
+  it('refuses a concrete path, which would defeat the privacy guarantee', async () => {
+    // The template is the whole point: '/v1/normas/29994' is a record of which
+    // law someone read. Catching this in a unit test is cheaper than catching
+    // it in a privacy review after six months of logs.
+    query.mockResolvedValue({ rows: [] })
+    const { recordUsage } = await import('./apiusage')
+    await recordUsage(7, '/v1/normas/29994', 200, 5)
+    expect(query).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalled()
+  })
+
+  it('accepts every template the API actually uses', async () => {
+    query.mockResolvedValue({ rows: [] })
+    const { recordUsage } = await import('./apiusage')
+    for (const t of [
+      '/v1/search',
+      '/v1/normas/{idNorma}',
+      '/v1/normas/{idNorma}/articulos',
+      '/v1/normas/{idNorma}/articulos/{slug}',
+      '/v1/normas/{idNorma}/versiones',
+      '/v1/normas/{idNorma}/diff',
+      '/v1/normas/{idNorma}/modificaciones',
+      '/v1/normas/{idNorma}/raw',
+    ]) {
+      await recordUsage(7, t, 200, 1)
+    }
+    expect(query).toHaveBeenCalledTimes(8)
+  })
+})
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd site && pnpm vitest run lib/apiusage.test.ts`
+Expected: FAIL — `Cannot find module './apiusage'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `site/lib/apiusage.ts`:
+
+```ts
+import { pool } from './db'
+
+/** Endpoint strings must be route templates, not concrete paths.
+ *
+ *  A digit where `{idNorma}` belongs means a caller passed the real path, which
+ *  would turn this table into a record of which laws each key holder read. That
+ *  is the exact data this design chose not to collect, so it is refused rather
+ *  than written. */
+const TEMPLATE_RE = /^\/v1\/[a-z{}/]*$/
+
+/** Record one API call. Never throws.
+ *
+ *  Callers dispatch this without awaiting, so a rejection would surface as an
+ *  unhandled promise rejection and, on some runtimes, take the process down —
+ *  over a metric. Observability must never be able to fail a request that
+ *  already produced a correct response. */
+export async function recordUsage(
+  keyId: number, endpoint: string, status: number, durationMs: number,
+): Promise<void> {
+  if (!TEMPLATE_RE.test(endpoint)) {
+    console.error(
+      `[api] refusing to record a concrete path as usage: ${endpoint} — ` +
+      `endpoint must be a route template such as /v1/normas/{idNorma}`,
+    )
+    return
+  }
+  try {
+    await pool.query(
+      `INSERT INTO api_usage (key_id, endpoint, status, duration_ms)
+       VALUES ($1, $2, $3, $4)`,
+      [keyId, endpoint, status, durationMs],
+    )
+  } catch (err) {
+    console.error('[api] usage insert failed:', err)
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `cd site && pnpm vitest run lib/apiusage.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add site/lib/apiusage.ts site/lib/apiusage.test.ts
+git commit --no-gpg-sign -m "feat(api): record per-key usage, refusing concrete paths
+
+Writes key, endpoint template, status and duration. Never throws:
+callers dispatch it without awaiting, so a rejection would surface as an
+unhandled rejection over a metric.
+
+A concrete path is refused rather than written. '/v1/normas/29994' is a
+record of which law a caller read — the data this design chose not to
+collect — and a unit test is a cheaper place to catch that than a
+privacy review six months of logs later."
+```
+
+---
+
+### Task 4: The `withApiKey` wrapper
+
+**Files:**
+- Create: `site/lib/apiroute.ts`
+- Test: `site/lib/apiroute.test.ts`
+
+**Interfaces:**
+- Consumes: `verifyApiKey` (Task 2), `recordUsage` (Task 3).
+- Produces: `apiError(status: number, code: string, message: string): Response`, `jsonOk(body: unknown, cacheSeconds?: number): Response`, `withApiKey(endpoint: string, handler: ApiHandler): (req: Request, ctx: RouteCtx) => Promise<Response>`, `type RouteCtx = { params: Promise<Record<string, string>> }`, `type ApiHandler = (req: Request, ctx: RouteCtx) => Promise<Response>`, and `class NotFound extends Error` / `class BadRequest extends Error`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `site/lib/apiroute.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const verifyApiKey = vi.fn()
+const recordUsage = vi.fn()
+vi.mock('./apikey', () => ({ verifyApiKey }))
+vi.mock('./apiusage', () => ({ recordUsage }))
+
+beforeEach(() => {
+  vi.resetModules()
+  verifyApiKey.mockReset()
+  recordUsage.mockReset().mockResolvedValue(undefined)
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+const CTX = { params: Promise.resolve({}) }
+const req = (auth?: string) =>
+  new Request('https://x/v1/search?q=a', auth ? { headers: { authorization: auth } } : undefined)
+
+async function wrap(handler: () => Promise<Response>) {
+  const { withApiKey } = await import('./apiroute')
+  return withApiKey('/v1/search', handler)
+}
+
+describe('withApiKey', () => {
+  it('401s with no Authorization header, and records nothing', async () => {
+    const res = await (await wrap(async () => Response.json({})))(req(), CTX)
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: { code: 'missing_api_key', message: expect.any(String) } })
+    // Unattributable traffic cannot be recorded — there is no key to attribute it to.
+    expect(recordUsage).not.toHaveBeenCalled()
+  })
+
+  it('401s on a non-Bearer scheme', async () => {
+    const res = await (await wrap(async () => Response.json({})))(req('Basic abc'), CTX)
+    expect(res.status).toBe(401)
+  })
+
+  it('401s on an unknown or revoked key', async () => {
+    verifyApiKey.mockResolvedValue(null)
+    const res = await (await wrap(async () => Response.json({})))(req('Bearer lc_live_x'), CTX)
+    expect(res.status).toBe(401)
+    expect((await res.json()).error.code).toBe('invalid_api_key')
+  })
+
+  it('runs the handler for a valid key and records the call', async () => {
+    verifyApiKey.mockResolvedValue({ id: 7, label: 'Acme' })
+    const res = await (await wrap(async () => Response.json({ ok: true })))(req('Bearer lc_live_x'), CTX)
+    expect(res.status).toBe(200)
+    const [keyId, endpoint, status, duration] = recordUsage.mock.calls[0]
+    expect(keyId).toBe(7)
+    expect(endpoint).toBe('/v1/search')
+    expect(status).toBe(200)
+    expect(typeof duration).toBe('number')
+  })
+
+  it('turns a database failure into 503, never a 200 with empty data', async () => {
+    // The 2026-09-07 outage in one assertion: a broken dependency was reported
+    // as an empty successful result, so monitoring saw only healthy 200s.
+    verifyApiKey.mockResolvedValue({ id: 7, label: 'Acme' })
+    const boom = async () => { throw new Error('connection terminated') }
+    const res = await (await wrap(boom))(req('Bearer lc_live_x'), CTX)
+    expect(res.status).toBe(503)
+    expect((await res.json()).error.code).toBe('service_unavailable')
+    expect(recordUsage.mock.calls[0][2]).toBe(503)
+  })
+
+  it('maps NotFound to 404 and BadRequest to 400', async () => {
+    verifyApiKey.mockResolvedValue({ id: 7, label: 'Acme' })
+    const { NotFound, BadRequest } = await import('./apiroute')
+    const nf = await (await wrap(async () => { throw new NotFound('no such norma') }))(req('Bearer k'), CTX)
+    expect(nf.status).toBe(404)
+    expect((await nf.json()).error.code).toBe('not_found')
+    const br = await (await wrap(async () => { throw new BadRequest('bad fecha') }))(req('Bearer k'), CTX)
+    expect(br.status).toBe(400)
+    expect((await br.json()).error.code).toBe('bad_request')
+  })
+
+  it('does not fail the request when usage recording rejects', async () => {
+    verifyApiKey.mockResolvedValue({ id: 7, label: 'Acme' })
+    recordUsage.mockRejectedValue(new Error('db down'))
+    const res = await (await wrap(async () => Response.json({ ok: true })))(req('Bearer k'), CTX)
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('jsonOk', () => {
+  it('marks responses private so no shared cache stores authenticated data', async () => {
+    const { jsonOk } = await import('./apiroute')
+    const cc = jsonOk({ a: 1 }, 300).headers.get('cache-control')
+    expect(cc).toContain('private')
+    expect(cc).not.toContain('public')
+    expect(cc).toContain('max-age=300')
+  })
+})
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd site && pnpm vitest run lib/apiroute.test.ts`
+Expected: FAIL — `Cannot find module './apiroute'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `site/lib/apiroute.ts`:
+
+```ts
+import { verifyApiKey } from './apikey'
+import { recordUsage } from './apiusage'
+
+export type RouteCtx = { params: Promise<Record<string, string>> }
+export type ApiHandler = (req: Request, ctx: RouteCtx) => Promise<Response>
+
+/** Handler-thrown signals the wrapper maps to status codes, so route handlers
+ *  return data or throw meaning, and never assemble error responses. */
+export class NotFound extends Error {}
+export class BadRequest extends Error {}
+
+export function apiError(status: number, code: string, message: string): Response {
+  return Response.json({ error: { code, message } }, { status })
+}
+
+/** `private`, never `public`: these responses sit behind an Authorization
+ *  header and must not be stored by a shared cache. */
+export function jsonOk(body: unknown, cacheSeconds = 0): Response {
+  const headers: Record<string, string> = { 'content-type': 'application/json' }
+  if (cacheSeconds > 0) headers['cache-control'] = `private, max-age=${cacheSeconds}`
+  return new Response(JSON.stringify(body), { status: 200, headers })
+}
+
+/** Authenticate, time, record, and normalise errors for one endpoint.
+ *
+ *  `endpoint` MUST be the route template ('/v1/normas/{idNorma}'), because it
+ *  is what gets logged — see lib/apiusage.ts.
+ *
+ *  An unrecognised throw becomes 503, not 200-with-nothing. On 2026-09-07 a
+ *  dependency failure was reported as an empty successful result and a total
+ *  outage looked, to monitoring, like a wall of healthy 200s. */
+export function withApiKey(endpoint: string, handler: ApiHandler) {
+  return async (req: Request, ctx: RouteCtx): Promise<Response> => {
+    const started = Date.now()
+    const auth = req.headers.get('authorization') ?? ''
+    const m = /^Bearer\s+(\S+)$/i.exec(auth)
+    if (!m) {
+      return apiError(401, 'missing_api_key',
+        'Provide an API key as: Authorization: Bearer lc_live_…')
+    }
+
+    const key = await verifyApiKey(m[1])
+    if (!key) {
+      return apiError(401, 'invalid_api_key', 'The API key is unknown or has been revoked.')
+    }
+
+    let res: Response
+    try {
+      res = await handler(req, ctx)
+    } catch (err) {
+      if (err instanceof NotFound) {
+        res = apiError(404, 'not_found', err.message)
+      } else if (err instanceof BadRequest) {
+        res = apiError(400, 'bad_request', err.message)
+      } else {
+        console.error(`[api] ${endpoint} failed:`, err)
+        res = apiError(503, 'service_unavailable', 'The service is temporarily unavailable.')
+      }
+    }
+
+    // Dispatched, not awaited: recording must add no latency. The site runs a
+    // single persistent Node replica, so the insert completes after the
+    // response is sent. `.catch` because recordUsage's own guard could still be
+    // bypassed by a rejection at dispatch time.
+    void recordUsage(key.id, endpoint, res.status, Date.now() - started)
+      .catch((e) => console.error('[api] usage dispatch failed:', e))
+
+    return res
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `cd site && pnpm vitest run lib/apiroute.test.ts`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add site/lib/apiroute.ts site/lib/apiroute.test.ts
+git commit --no-gpg-sign -m "feat(api): withApiKey wrapper for auth, timing, errors and usage
+
+One place handles authentication, the error envelope, response timing
+and usage recording, so no route handler repeats any of it. Handlers
+return data or throw NotFound/BadRequest; the wrapper maps those to 404
+and 400 and anything unrecognised to 503.
+
+That last mapping is the 2026-09-07 lesson: a dependency failure
+reported as an empty successful result made a total outage look like a
+wall of healthy 200s. Responses are Cache-Control: private, never
+public, because they sit behind an Authorization header."
+```
+
+---
+
+### Task 5: `GET /v1/search`
+
+**Files:**
+- Create: `site/app/api/v1/search/route.ts`
+- Test: `site/app/api/v1/search/route.test.ts`
+
+**Interfaces:**
+- Consumes: `withApiKey`, `jsonOk`, `BadRequest` (Task 4); `runSearch` from `@/lib/search`; `getNormasByKey`, `getOrganismosByIds` from `@/lib/norma`.
+- Produces: `GET` handler. Response shape `{ query, asOf, total, resultados: Array<{ idNorma, tipo, numero, titulo, organismo }> }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `site/app/api/v1/search/route.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const runSearch = vi.fn()
+const getNormasByKey = vi.fn()
+const getOrganismosByIds = vi.fn()
+vi.mock('@/lib/search', () => ({ runSearch }))
+vi.mock('@/lib/norma', () => ({ getNormasByKey, getOrganismosByIds }))
+vi.mock('@/lib/apikey', () => ({ verifyApiKey: vi.fn().mockResolvedValue({ id: 1, label: 'T' }) }))
+vi.mock('@/lib/apiusage', () => ({ recordUsage: vi.fn().mockResolvedValue(undefined) }))
+
+beforeEach(() => {
+  vi.resetModules()
+  runSearch.mockReset()
+  getNormasByKey.mockReset()
+  getOrganismosByIds.mockReset().mockResolvedValue(new Map([[29994, 'MINISTERIO DEL INTERIOR']]))
+})
+
+const CTX = { params: Promise.resolve({}) }
+const call = async (qs: string) => {
+  const { GET } = await import('./route')
+  return GET(new Request(`https://x/v1/search?${qs}`, {
+    headers: { authorization: 'Bearer lc_live_x' },
+  }), CTX)
+}
+
+const HIT = { idNorma: 29994, tipo: 'ley', numero: '18603', titulo: 'LOC DE LOS PARTIDOS POLITICOS' }
+
+describe('GET /v1/search', () => {
+  it('returns free-text results enriched with organismo', async () => {
+    runSearch.mockResolvedValue([HIT])
+    const res = await call('q=partidos')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.total).toBe(1)
+    expect(body.resultados[0]).toEqual({
+      idNorma: 29994, tipo: 'ley', numero: '18603',
+      titulo: 'LOC DE LOS PARTIDOS POLITICOS', organismo: 'MINISTERIO DEL INTERIOR',
+    })
+  })
+
+  it('400s when neither q nor a tipo/numero pair is given', async () => {
+    const res = await call('')
+    expect(res.status).toBe(400)
+    expect((await res.json()).error.code).toBe('bad_request')
+  })
+
+  it('resolves a citation to every candidate, since (tipo, numero) is ambiguous', async () => {
+    // Several DFL 1 exist, one per organismo. Returning one of them silently
+    // would be the /ley/20780 bug all over again.
+    getNormasByKey.mockResolvedValue([
+      { ...HIT, idNorma: 1, tipo: 'dfl', numero: '1', organismo: 'TRABAJO' },
+      { ...HIT, idNorma: 2, tipo: 'dfl', numero: '1', organismo: 'SALUD' },
+    ])
+    const res = await call('tipo=dfl&numero=1')
+    const body = await res.json()
+    expect(body.total).toBe(2)
+    expect(body.resultados.map((r: { idNorma: number }) => r.idNorma)).toEqual([1, 2])
+    expect(runSearch).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed asOf rather than silently searching today', async () => {
+    const res = await call('q=x&asOf=ayer')
+    expect(res.status).toBe(400)
+  })
+
+  it('caps limit so one call cannot ask for the whole corpus', async () => {
+    runSearch.mockResolvedValue([])
+    await call('q=x&limit=9999')
+    expect(runSearch.mock.calls[0][2]).toBe(100)
+  })
+})
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd site && pnpm vitest run app/api/v1/search/route.test.ts`
+Expected: FAIL — `Cannot find module './route'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `site/app/api/v1/search/route.ts`:
+
+```ts
+import { runSearch } from '@/lib/search'
+import { getNormasByKey, getOrganismosByIds } from '@/lib/norma'
+import { withApiKey, jsonOk, BadRequest } from '@/lib/apiroute'
+
+const MAX_LIMIT = 100
+const FECHA_RE = /^\d{4}-\d{2}-\d{2}$/
+
+interface Result {
+  idNorma: number
+  tipo: string
+  numero: string
+  titulo: string
+  organismo: string
+}
+
+/** Search the corpus, either by free text (`q`) or by citation
+ *  (`tipo` + `numero`).
+ *
+ *  A citation returns EVERY candidate rather than a best guess: (tipo, numero)
+ *  is not unique — there are many "DFL 1", one per organismo — and picking one
+ *  silently is how /ley/20780 once resolved to an unrelated decreto. Callers
+ *  disambiguate on `idNorma`, which is unique. */
+export const GET = withApiKey('/v1/search', async (req) => {
+  const url = new URL(req.url)
+  const q = url.searchParams.get('q')?.trim() ?? ''
+  const tipo = url.searchParams.get('tipo')?.trim() ?? ''
+  const numero = url.searchParams.get('numero')?.trim() ?? ''
+  const asOf = url.searchParams.get('asOf') ?? new Date().toISOString().slice(0, 10)
+
+  if (!FECHA_RE.test(asOf)) {
+    throw new BadRequest(`asOf must be YYYY-MM-DD, got "${asOf}"`)
+  }
+
+  const rawLimit = Number(url.searchParams.get('limit') ?? 20)
+  const limit = Number.isFinite(rawLimit)
+    ? Math.min(Math.max(Math.trunc(rawLimit), 1), MAX_LIMIT)
+    : 20
+
+  let resultados: Result[]
+
+  if (tipo && numero) {
+    const normas = await getNormasByKey(tipo, numero)
+    resultados = normas.slice(0, limit).map((n) => ({
+      idNorma: n.idNorma, tipo: n.tipo, numero: n.numero,
+      titulo: n.titulo, organismo: n.organismo,
+    }))
+  } else if (q.length >= 2) {
+    const hits = await runSearch(q, asOf, limit)
+    const orgs = await getOrganismosByIds(hits.map((h) => h.idNorma))
+    resultados = hits.map((h) => ({
+      idNorma: h.idNorma, tipo: h.tipo, numero: h.numero,
+      titulo: h.titulo, organismo: orgs.get(h.idNorma) ?? '',
+    }))
+  } else {
+    throw new BadRequest(
+      'Provide q (at least 2 characters) for free-text search, or tipo and numero for a citation.',
+    )
+  }
+
+  return jsonOk({ query: q || `${tipo} ${numero}`.trim(), asOf, total: resultados.length, resultados })
+})
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `cd site && pnpm vitest run app/api/v1/search/route.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add site/app/api/v1/search/route.ts site/app/api/v1/search/route.test.ts
+git commit --no-gpg-sign -m "feat(api): GET /v1/search
+
+Free text via q, or a citation via tipo+numero. A citation returns every
+candidate rather than a best guess: (tipo, numero) is not unique — there
+are many DFL 1, one per organismo — and picking one silently is how
+/ley/20780 once resolved to an unrelated decreto. Callers disambiguate
+on idNorma.
+
+limit is capped at 100 so one call cannot ask for the whole corpus, and
+a malformed asOf is a 400 rather than a silent search of today."
+```
+
+---
+
+### Task 6: Norma metadata and articles
+
+**Files:**
+- Create: `site/app/api/v1/normas/[idNorma]/route.ts`
+- Create: `site/app/api/v1/normas/[idNorma]/articulos/route.ts`
+- Create: `site/app/api/v1/normas/[idNorma]/articulos/[slug]/route.ts`
+- Create: `site/lib/apiparams.ts`
+- Test: `site/lib/apiparams.test.ts`
+- Test: `site/app/api/v1/normas/normas.route.test.ts`
+
+**Interfaces:**
+- Consumes: `withApiKey`, `jsonOk`, `NotFound`, `BadRequest` (Task 4); `getNormaById`, `getArticlesAsOf`, `getVersions`, `currentFecha` from `@/lib/norma`; `searchArticles` from `@/lib/search`.
+- Produces: `parseIdNorma(raw: string): number` and `parseFecha(raw: string | null, fallback: string): string` in `site/lib/apiparams.ts`; three `GET` handlers.
+
+- [ ] **Step 1: Write the failing test for the shared parameter parsing**
+
+Create `site/lib/apiparams.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { parseIdNorma, parseFecha } from './apiparams'
+import { BadRequest } from './apiroute'
+
+describe('parseIdNorma', () => {
+  it('accepts a positive integer', () => {
+    expect(parseIdNorma('29994')).toBe(29994)
+  })
+  it('rejects anything that is not one', () => {
+    // A NaN reaching a SQL parameter is a 500 waiting to happen.
+    for (const bad of ['', 'abc', '-1', '0', '1.5', '12e3', ' 12 ']) {
+      expect(() => parseIdNorma(bad)).toThrow(BadRequest)
+    }
+  })
+})
+
+describe('parseFecha', () => {
+  it('accepts YYYY-MM-DD and falls back when absent', () => {
+    expect(parseFecha('2020-01-31', '2026-01-01')).toBe('2020-01-31')
+    expect(parseFecha(null, '2026-01-01')).toBe('2026-01-01')
+  })
+  it('rejects a malformed date rather than searching an unintended day', () => {
+    for (const bad of ['ayer', '2020-1-1', '20200101', '2020-13-01']) {
+      expect(() => parseFecha(bad, '2026-01-01')).toThrow(BadRequest)
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd site && pnpm vitest run lib/apiparams.test.ts`
+Expected: FAIL — `Cannot find module './apiparams'`.
+
+- [ ] **Step 3: Write the parameter parsing**
+
+Create `site/lib/apiparams.ts`:
+
+```ts
+import { BadRequest } from './apiroute'
+
+/** Strict positive integer. Anything else is a 400, never a NaN handed to a
+ *  SQL parameter. */
+export function parseIdNorma(raw: string): number {
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new BadRequest(`idNorma must be a positive integer, got "${raw}"`)
+  }
+  return Number(raw)
+}
+
+/** YYYY-MM-DD, validated as a real calendar date. A malformed fecha must not
+ *  silently become "today" — the answer would be right-looking and wrong. */
+export function parseFecha(raw: string | null, fallback: string): string {
+  if (raw === null || raw === '') return fallback
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    throw new BadRequest(`fecha must be YYYY-MM-DD, got "${raw}"`)
+  }
+  const d = new Date(`${raw}T00:00:00Z`)
+  if (Number.isNaN(d.getTime()) || d.toISOString().slice(0, 10) !== raw) {
+    throw new BadRequest(`fecha is not a real date: "${raw}"`)
+  }
+  return raw
+}
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `cd site && pnpm vitest run lib/apiparams.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Write the failing tests for the three routes**
+
+Create `site/app/api/v1/normas/normas.route.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getNormaById = vi.fn()
+const getArticlesAsOf = vi.fn()
+const getVersions = vi.fn()
+const currentFecha = vi.fn()
+const searchArticles = vi.fn()
+vi.mock('@/lib/norma', () => ({ getNormaById, getArticlesAsOf, getVersions, currentFecha }))
+vi.mock('@/lib/search', () => ({ searchArticles }))
+vi.mock('@/lib/apikey', () => ({ verifyApiKey: vi.fn().mockResolvedValue({ id: 1, label: 'T' }) }))
+vi.mock('@/lib/apiusage', () => ({ recordUsage: vi.fn().mockResolvedValue(undefined) }))
+
+const NORMA = {
+  idNorma: 29994, tipo: 'ley', numero: '18603', titulo: 'LOC PARTIDOS',
+  organismo: 'INTERIOR', derogado: false, fechaPublicacion: '1987-03-11', lawDir: 'leyes/18603',
+}
+const ART = { slug: 'a1', label: 'Artículo 1', rawHeading: 'Artículo 1º', body: 'Cuerpo.', ord: 0 }
+
+beforeEach(() => {
+  vi.resetModules()
+  for (const m of [getNormaById, getArticlesAsOf, getVersions, currentFecha, searchArticles]) m.mockReset()
+  getNormaById.mockResolvedValue(NORMA)
+  getVersions.mockResolvedValue([{ desde: '1987-03-11', hasta: null, commitSha: 'a', causaId: null, subject: 's' }])
+  currentFecha.mockReturnValue('1987-03-11')
+  getArticlesAsOf.mockResolvedValue([ART])
+})
+
+const H = { headers: { authorization: 'Bearer lc_live_x' } }
+
+describe('GET /v1/normas/{idNorma}', () => {
+  it('returns metadata and an article index without bodies', async () => {
+    // A single norma can be ~350KB. The index lists articles; bodies are
+    // fetched one at a time.
+    const { GET } = await import('./[idNorma]/route')
+    const res = await GET(new Request('https://x/v1/normas/29994', H),
+      { params: Promise.resolve({ idNorma: '29994' }) })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.titulo).toBe('LOC PARTIDOS')
+    expect(body.articulos).toEqual([{ slug: 'a1', label: 'Artículo 1', rawHeading: 'Artículo 1º' }])
+    expect(JSON.stringify(body)).not.toContain('Cuerpo.')
+  })
+
+  it('404s for an unknown norma', async () => {
+    getNormaById.mockResolvedValue(null)
+    const { GET } = await import('./[idNorma]/route')
+    const res = await GET(new Request('https://x/v1/normas/1', H),
+      { params: Promise.resolve({ idNorma: '1' }) })
+    expect(res.status).toBe(404)
+  })
+
+  it('400s on a non-numeric idNorma', async () => {
+    const { GET } = await import('./[idNorma]/route')
+    const res = await GET(new Request('https://x/v1/normas/abc', H),
+      { params: Promise.resolve({ idNorma: 'abc' }) })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('GET /v1/normas/{idNorma}/articulos', () => {
+  it('lists the article index at a fecha', async () => {
+    const { GET } = await import('./[idNorma]/articulos/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/articulos?fecha=2020-01-01', H),
+      { params: Promise.resolve({ idNorma: '29994' }) })
+    expect(res.status).toBe(200)
+    expect(getArticlesAsOf).toHaveBeenCalledWith(29994, '2020-01-01')
+    expect((await res.json()).articulos[0].slug).toBe('a1')
+  })
+
+  it('adds snippets and drops non-matching articles when q is given', async () => {
+    searchArticles.mockResolvedValue([
+      { slug: 'a1', label: 'Artículo 1', rawHeading: 'Artículo 1º', snippet: '…<b>cuerpo</b>…' },
+    ])
+    const { GET } = await import('./[idNorma]/articulos/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/articulos?q=cuerpo', H),
+      { params: Promise.resolve({ idNorma: '29994' }) })
+    const body = await res.json()
+    expect(searchArticles).toHaveBeenCalled()
+    expect(body.articulos[0].snippet).toContain('cuerpo')
+  })
+})
+
+describe('GET /v1/normas/{idNorma}/articulos/{slug}', () => {
+  it('returns one article body', async () => {
+    const { GET } = await import('./[idNorma]/articulos/[slug]/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/articulos/a1', H),
+      { params: Promise.resolve({ idNorma: '29994', slug: 'a1' }) })
+    expect(res.status).toBe(200)
+    expect((await res.json()).body).toBe('Cuerpo.')
+  })
+
+  it('404s for a slug that is not in this norma', async () => {
+    const { GET } = await import('./[idNorma]/articulos/[slug]/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/articulos/zz', H),
+      { params: Promise.resolve({ idNorma: '29994', slug: 'zz' }) })
+    expect(res.status).toBe(404)
+  })
+
+  it('truncates a very long body and says so', async () => {
+    getArticlesAsOf.mockResolvedValue([{ ...ART, body: 'x'.repeat(20_000) }])
+    const { GET } = await import('./[idNorma]/articulos/[slug]/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/articulos/a1', H),
+      { params: Promise.resolve({ idNorma: '29994', slug: 'a1' }) })
+    const body = await res.json()
+    expect(body.body.length).toBeLessThan(20_000)
+    expect(body.truncado).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 6: Run them to make sure they fail**
+
+Run: `cd site && pnpm vitest run app/api/v1/normas/normas.route.test.ts`
+Expected: FAIL — cannot find `./[idNorma]/route`.
+
+- [ ] **Step 7: Write the three route handlers**
+
+Create `site/app/api/v1/normas/[idNorma]/route.ts`:
+
+```ts
+import { getNormaById, getArticlesAsOf, getVersions, currentFecha } from '@/lib/norma'
+import { withApiKey, jsonOk, NotFound } from '@/lib/apiroute'
+import { parseIdNorma, parseFecha } from '@/lib/apiparams'
+
+/** Metadata plus an article INDEX — never article bodies.
+ *
+ *  One norma can be ~350 KB of text. Returning it whole would make the common
+ *  case (identify a law, then read one article) pay for the rare one. Bodies
+ *  come from /articulos/{slug}, one at a time. */
+export const GET = withApiKey('/v1/normas/{idNorma}', async (req, ctx) => {
+  const idNorma = parseIdNorma((await ctx.params).idNorma)
+  const norma = await getNormaById(idNorma)
+  if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
+
+  const versions = await getVersions(idNorma)
+  const fecha = parseFecha(new URL(req.url).searchParams.get('fecha'), currentFecha(versions))
+  const articulos = await getArticlesAsOf(idNorma, fecha)
+
+  return jsonOk({
+    idNorma: norma.idNorma,
+    tipo: norma.tipo,
+    numero: norma.numero,
+    titulo: norma.titulo,
+    organismo: norma.organismo,
+    derogado: norma.derogado,
+    fechaPublicacion: norma.fechaPublicacion,
+    fecha,
+    totalVersiones: versions.length,
+    articulos: articulos.map((a) => ({
+      slug: a.slug, label: a.label, rawHeading: a.rawHeading,
+    })),
+  }, 300)
+})
+```
+
+Create `site/app/api/v1/normas/[idNorma]/articulos/route.ts`:
+
+```ts
+import { getNormaById, getArticlesAsOf, getVersions, currentFecha } from '@/lib/norma'
+import { searchArticles } from '@/lib/search'
+import { withApiKey, jsonOk, NotFound } from '@/lib/apiroute'
+import { parseIdNorma, parseFecha } from '@/lib/apiparams'
+
+/** The article index at a fecha. With `q`, searches WITHIN the norma and
+ *  returns only matching articles, each with a snippet — the way to locate the
+ *  relevant article of a code with hundreds of them without pulling its text. */
+export const GET = withApiKey('/v1/normas/{idNorma}/articulos', async (req, ctx) => {
+  const idNorma = parseIdNorma((await ctx.params).idNorma)
+  const norma = await getNormaById(idNorma)
+  if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
+
+  const url = new URL(req.url)
+  const versions = await getVersions(idNorma)
+  const fecha = parseFecha(url.searchParams.get('fecha'), currentFecha(versions))
+  const q = url.searchParams.get('q')?.trim() ?? ''
+
+  if (q.length >= 2) {
+    const hits = await searchArticles(idNorma, q, fecha)
+    return jsonOk({
+      idNorma, fecha, query: q, total: hits.length,
+      articulos: hits.map((h) => ({
+        slug: h.slug, label: h.label, rawHeading: h.rawHeading, snippet: h.snippet,
+      })),
+    })
+  }
+
+  const articulos = await getArticlesAsOf(idNorma, fecha)
+  return jsonOk({
+    idNorma, fecha, total: articulos.length,
+    articulos: articulos.map((a) => ({
+      slug: a.slug, label: a.label, rawHeading: a.rawHeading,
+    })),
+  }, 300)
+})
+```
+
+Create `site/app/api/v1/normas/[idNorma]/articulos/[slug]/route.ts`:
+
+```ts
+import { getNormaById, getArticlesAsOf, getVersions, currentFecha } from '@/lib/norma'
+import { withApiKey, jsonOk, NotFound } from '@/lib/apiroute'
+import { parseIdNorma, parseFecha } from '@/lib/apiparams'
+
+/** Matches the cap the MCP server applies. A handful of articles in the corpus
+ *  are enormous; `truncado` tells the caller the text is incomplete rather than
+ *  letting them treat a cut-off article as the whole provision. */
+const MAX_BODY = 12_000
+
+export const GET = withApiKey('/v1/normas/{idNorma}/articulos/{slug}', async (req, ctx) => {
+  const params = await ctx.params
+  const idNorma = parseIdNorma(params.idNorma)
+  const slug = params.slug
+
+  const norma = await getNormaById(idNorma)
+  if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
+
+  const versions = await getVersions(idNorma)
+  const fecha = parseFecha(new URL(req.url).searchParams.get('fecha'), currentFecha(versions))
+  const articulos = await getArticlesAsOf(idNorma, fecha)
+  const art = articulos.find((a) => a.slug === slug)
+  if (!art) throw new NotFound(`No article "${slug}" in idNorma ${idNorma} as of ${fecha}`)
+
+  const truncado = art.body.length > MAX_BODY
+  return jsonOk({
+    idNorma, fecha, slug: art.slug, label: art.label, rawHeading: art.rawHeading,
+    body: truncado ? art.body.slice(0, MAX_BODY) : art.body,
+    truncado,
+    largoCompleto: art.body.length,
+  }, 300)
+})
+```
+
+- [ ] **Step 8: Run the tests and make sure they pass**
+
+Run: `cd site && pnpm vitest run app/api/v1/normas lib/apiparams.test.ts`
+Expected: PASS, 12 tests.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add site/lib/apiparams.ts site/lib/apiparams.test.ts site/app/api/v1/normas
+git commit --no-gpg-sign -m "feat(api): norma metadata and article endpoints
+
+GET /v1/normas/{idNorma} returns metadata plus an article INDEX, never
+bodies — one norma can be ~350KB, and returning it whole would make the
+common case pay for the rare one. Bodies come one at a time from
+/articulos/{slug}, capped at 12k with an explicit truncado flag so a
+cut-off article is never mistaken for a whole provision.
+
+/articulos takes an optional q that searches within the norma and
+returns only matching articles with snippets.
+
+parseIdNorma and parseFecha reject malformed input with 400 rather than
+handing a NaN to a SQL parameter or silently substituting today for an
+unparseable date."
+```
+
+---
+
+### Task 7: Versions, modifications, and the raw link
+
+**Files:**
+- Create: `site/app/api/v1/normas/[idNorma]/versiones/route.ts`
+- Create: `site/app/api/v1/normas/[idNorma]/modificaciones/route.ts`
+- Create: `site/app/api/v1/normas/[idNorma]/raw/route.ts`
+- Test: `site/app/api/v1/normas/relations.route.test.ts`
+
+**Interfaces:**
+- Consumes: `withApiKey`, `jsonOk`, `NotFound` (Task 4); `parseIdNorma`, `parseFecha` (Task 6); `getNormaById`, `getVersions`, `getModifies`, `getModifiedBy`, `currentFecha` from `@/lib/norma`.
+- Produces: three `GET` handlers.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `site/app/api/v1/normas/relations.route.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getNormaById = vi.fn()
+const getVersions = vi.fn()
+const getModifies = vi.fn()
+const getModifiedBy = vi.fn()
+const currentFecha = vi.fn()
+vi.mock('@/lib/norma', () => ({ getNormaById, getVersions, getModifies, getModifiedBy, currentFecha }))
+vi.mock('@/lib/apikey', () => ({ verifyApiKey: vi.fn().mockResolvedValue({ id: 1, label: 'T' }) }))
+vi.mock('@/lib/apiusage', () => ({ recordUsage: vi.fn().mockResolvedValue(undefined) }))
+
+const NORMA = {
+  idNorma: 29994, tipo: 'ley', numero: '18603', titulo: 'LOC PARTIDOS',
+  organismo: 'INTERIOR', derogado: false, fechaPublicacion: '1987-03-11', lawDir: 'leyes/18603',
+}
+const MOD = { idNorma: 242302, tipo: 'ley', numero: '20500', titulo: 'ASOCIACIONES', fecha: '2011-02-16' }
+
+beforeEach(() => {
+  vi.resetModules()
+  for (const m of [getNormaById, getVersions, getModifies, getModifiedBy, currentFecha]) m.mockReset()
+  getNormaById.mockResolvedValue(NORMA)
+  getVersions.mockResolvedValue([
+    { desde: '1987-03-11', hasta: '2011-02-15', commitSha: 'a', causaId: null, subject: 'orig' },
+    { desde: '2011-02-16', hasta: null, commitSha: 'b', causaId: 242302, subject: 'reforma' },
+  ])
+  currentFecha.mockReturnValue('2011-02-16')
+  getModifies.mockResolvedValue([])
+  getModifiedBy.mockResolvedValue([MOD])
+})
+
+const H = { headers: { authorization: 'Bearer lc_live_x' } }
+const P = { params: Promise.resolve({ idNorma: '29994' }) }
+
+describe('GET /v1/normas/{idNorma}/versiones', () => {
+  it('lists every version with its validity window', async () => {
+    const { GET } = await import('./[idNorma]/versiones/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/versiones', H), P)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.total).toBe(2)
+    expect(body.versiones[0]).toMatchObject({ desde: '1987-03-11', hasta: '2011-02-15' })
+    expect(body.vigente).toBe('2011-02-16')
+  })
+
+  it('404s for an unknown norma', async () => {
+    getNormaById.mockResolvedValue(null)
+    const { GET } = await import('./[idNorma]/versiones/route')
+    expect((await GET(new Request('https://x/v1/normas/29994/versiones', H), P)).status).toBe(404)
+  })
+})
+
+describe('GET /v1/normas/{idNorma}/modificaciones', () => {
+  it('returns both directions, each carrying idNorma', async () => {
+    // Without idNorma a caller would have to resolve (tipo, numero), which for
+    // a "DFL 4" reference is ambiguous many times over.
+    const { GET } = await import('./[idNorma]/modificaciones/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/modificaciones', H), P)
+    const body = await res.json()
+    expect(body.modificadaPor[0].idNorma).toBe(242302)
+    expect(body.modifica).toEqual([])
+  })
+})
+
+describe('GET /v1/normas/{idNorma}/raw', () => {
+  it('returns the canonical upstream link for a fecha', async () => {
+    const { GET } = await import('./[idNorma]/raw/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/raw?fecha=2011-02-16', H), P)
+    const body = await res.json()
+    expect(body.url).toContain('leychile.cl')
+    expect(body.url).toContain('29994')
+    expect(body.fecha).toBe('2011-02-16')
+  })
+})
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd site && pnpm vitest run app/api/v1/normas/relations.route.test.ts`
+Expected: FAIL — cannot find `./[idNorma]/versiones/route`.
+
+- [ ] **Step 3: Write the three handlers**
+
+Create `site/app/api/v1/normas/[idNorma]/versiones/route.ts`:
+
+```ts
+import { getNormaById, getVersions, currentFecha } from '@/lib/norma'
+import { withApiKey, jsonOk, NotFound } from '@/lib/apiroute'
+import { parseIdNorma } from '@/lib/apiparams'
+
+/** Every version of a norma with its validity window. `desde`/`hasta` are the
+ *  fechas to pass to the article and diff endpoints. */
+export const GET = withApiKey('/v1/normas/{idNorma}/versiones', async (_req, ctx) => {
+  const idNorma = parseIdNorma((await ctx.params).idNorma)
+  const norma = await getNormaById(idNorma)
+  if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
+
+  const versions = await getVersions(idNorma)
+  return jsonOk({
+    idNorma,
+    vigente: currentFecha(versions),
+    total: versions.length,
+    versiones: versions.map((v) => ({
+      desde: v.desde, hasta: v.hasta, causaId: v.causaId, subject: v.subject,
+    })),
+  }, 300)
+})
+```
+
+Create `site/app/api/v1/normas/[idNorma]/modificaciones/route.ts`:
+
+```ts
+import { getNormaById, getModifies, getModifiedBy } from '@/lib/norma'
+import { withApiKey, jsonOk, NotFound } from '@/lib/apiroute'
+import { parseIdNorma } from '@/lib/apiparams'
+
+/** Both directions of the modification graph.
+ *
+ *  Every entry carries `idNorma`, so a caller can address the related norma
+ *  directly instead of resolving (tipo, numero) — which for a "DFL 4"
+ *  reference is ambiguous many times over. */
+export const GET = withApiKey('/v1/normas/{idNorma}/modificaciones', async (_req, ctx) => {
+  const idNorma = parseIdNorma((await ctx.params).idNorma)
+  const norma = await getNormaById(idNorma)
+  if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
+
+  const [modifica, modificadaPor] = await Promise.all([
+    getModifies(idNorma),
+    getModifiedBy(idNorma),
+  ])
+  const shape = (m: { idNorma: number; tipo: string; numero: string; titulo: string; fecha: string }) => ({
+    idNorma: m.idNorma, tipo: m.tipo, numero: m.numero, titulo: m.titulo, fecha: m.fecha,
+  })
+
+  return jsonOk({ idNorma, modifica: modifica.map(shape), modificadaPor: modificadaPor.map(shape) }, 300)
+})
+```
+
+Create `site/app/api/v1/normas/[idNorma]/raw/route.ts`:
+
+```ts
+import { getNormaById, getVersions, currentFecha } from '@/lib/norma'
+import { withApiKey, jsonOk, NotFound } from '@/lib/apiroute'
+import { parseIdNorma, parseFecha } from '@/lib/apiparams'
+
+/** The canonical leychile.cl URL for one version — the authoritative source
+ *  this corpus is derived from, for anyone who needs to cite or verify it. */
+export const GET = withApiKey('/v1/normas/{idNorma}/raw', async (req, ctx) => {
+  const idNorma = parseIdNorma((await ctx.params).idNorma)
+  const norma = await getNormaById(idNorma)
+  if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
+
+  const versions = await getVersions(idNorma)
+  const fecha = parseFecha(new URL(req.url).searchParams.get('fecha'), currentFecha(versions))
+
+  return jsonOk({
+    idNorma,
+    fecha,
+    url: `https://www.leychile.cl/Navegar?idNorma=${idNorma}&idVersion=${fecha}`,
+    xml: `https://www.leychile.cl/Consulta/obtxml?opt=7&idNorma=${idNorma}&idVersion=${fecha}`,
+  }, 300)
+})
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `cd site && pnpm vitest run app/api/v1/normas/relations.route.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add site/app/api/v1/normas
+git commit --no-gpg-sign -m "feat(api): versiones, modificaciones and raw endpoints
+
+Version windows are what the article and diff endpoints take as fechas,
+so they are returned as desde/hasta pairs rather than a formatted list.
+
+Modification entries carry idNorma in both directions, so a caller can
+address the related norma directly instead of resolving (tipo, numero),
+which for a DFL 4 reference is ambiguous many times over."
+```
+
+---
+
+### Task 8: `GET /v1/normas/{idNorma}/diff`
+
+**Files:**
+- Create: `site/app/api/v1/normas/[idNorma]/diff/route.ts`
+- Test: `site/app/api/v1/normas/diff.route.test.ts`
+
+**Interfaces:**
+- Consumes: `withApiKey`, `jsonOk`, `NotFound`, `BadRequest` (Task 4); `parseIdNorma`, `parseFecha` (Task 6); `getNormaById`, `getArticlesAsOf` from `@/lib/norma`; `align`, `wordDiff`, `joinDiffText` from `@/lib/diff`.
+- Produces: `GET` handler returning `{ idNorma, from, to, resumen: { modificados, añadidos, eliminados }, cambios: Array<{ slug, rawHeading, estado, ops? , body? }> }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `site/app/api/v1/normas/diff.route.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getNormaById = vi.fn()
+const getArticlesAsOf = vi.fn()
+vi.mock('@/lib/norma', () => ({ getNormaById, getArticlesAsOf }))
+vi.mock('@/lib/apikey', () => ({ verifyApiKey: vi.fn().mockResolvedValue({ id: 1, label: 'T' }) }))
+vi.mock('@/lib/apiusage', () => ({ recordUsage: vi.fn().mockResolvedValue(undefined) }))
+
+const NORMA = {
+  idNorma: 29994, tipo: 'ley', numero: '18603', titulo: 'LOC PARTIDOS',
+  organismo: 'INTERIOR', derogado: false, fechaPublicacion: '1987-03-11', lawDir: 'leyes/18603',
+}
+const art = (slug: string, body: string) => ({
+  slug, label: `Artículo ${slug}`, rawHeading: `Artículo ${slug}`, body, ord: 0,
+})
+
+beforeEach(() => {
+  vi.resetModules()
+  getNormaById.mockReset().mockResolvedValue(NORMA)
+  getArticlesAsOf.mockReset()
+})
+
+const H = { headers: { authorization: 'Bearer lc_live_x' } }
+const P = { params: Promise.resolve({ idNorma: '29994' }) }
+const call = async (qs: string) => {
+  const { GET } = await import('./[idNorma]/diff/route')
+  return GET(new Request(`https://x/v1/normas/29994/diff?${qs}`, H), P)
+}
+
+describe('GET /v1/normas/{idNorma}/diff', () => {
+  it('reports modified, added and removed articles', async () => {
+    getArticlesAsOf
+      .mockResolvedValueOnce([art('a1', 'el plazo es de 30 dias'), art('a2', 'se elimina')])
+      .mockResolvedValueOnce([art('a1', 'el plazo es de 60 dias'), art('a3', 'nuevo')])
+    const res = await call('from=2010-01-01&to=2020-01-01')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.resumen).toEqual({ modificados: 1, añadidos: 1, eliminados: 1 })
+    const mod = body.cambios.find((c: { estado: string }) => c.estado === 'modificado')
+    expect(mod.slug).toBe('a1')
+    expect(JSON.stringify(mod.ops)).toContain('60')
+  })
+
+  it('returns an empty change set when nothing changed, not an error', async () => {
+    getArticlesAsOf
+      .mockResolvedValueOnce([art('a1', 'igual')])
+      .mockResolvedValueOnce([art('a1', 'igual')])
+    const res = await call('from=2010-01-01&to=2020-01-01')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.cambios).toEqual([])
+    expect(body.resumen).toEqual({ modificados: 0, añadidos: 0, eliminados: 0 })
+  })
+
+  it('400s when from or to is missing', async () => {
+    expect((await call('from=2010-01-01')).status).toBe(400)
+    expect((await call('to=2020-01-01')).status).toBe(400)
+  })
+
+  it('404s when neither fecha has any text', async () => {
+    getArticlesAsOf.mockResolvedValue([])
+    expect((await call('from=1800-01-01&to=1801-01-01')).status).toBe(404)
+  })
+})
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd site && pnpm vitest run app/api/v1/normas/diff.route.test.ts`
+Expected: FAIL — cannot find `./[idNorma]/diff/route`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `site/app/api/v1/normas/[idNorma]/diff/route.ts`:
+
+```ts
+import { getNormaById, getArticlesAsOf } from '@/lib/norma'
+import { align, wordDiff, joinDiffText } from '@/lib/diff'
+import { withApiKey, jsonOk, NotFound, BadRequest } from '@/lib/apiroute'
+import { parseIdNorma, parseFecha } from '@/lib/apiparams'
+
+const MAX_ADDED_BODY = 4_000
+
+/** What changed in a norma between two fechas.
+ *
+ *  This is the central question the corpus exists to answer — "how did this law
+ *  read before the reform?" — so the diff is returned structured rather than
+ *  rendered: callers get per-article insert/delete operations and can present
+ *  them however they like. The MCP server renders the same data as prose. */
+export const GET = withApiKey('/v1/normas/{idNorma}/diff', async (req, ctx) => {
+  const idNorma = parseIdNorma((await ctx.params).idNorma)
+  const url = new URL(req.url)
+  const rawFrom = url.searchParams.get('from')
+  const rawTo = url.searchParams.get('to')
+  if (!rawFrom || !rawTo) {
+    throw new BadRequest('Both from and to are required (YYYY-MM-DD).')
+  }
+  const from = parseFecha(rawFrom, rawFrom)
+  const to = parseFecha(rawTo, rawTo)
+
+  const norma = await getNormaById(idNorma)
+  if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
+
+  const [prev, curr] = await Promise.all([
+    getArticlesAsOf(idNorma, from),
+    getArticlesAsOf(idNorma, to),
+  ])
+  if (prev.length === 0 && curr.length === 0) {
+    throw new NotFound(`No text for idNorma ${idNorma} at either ${from} or ${to}`)
+  }
+
+  const changed = align(prev, curr).filter((a) => a.status !== 'unchanged')
+
+  const cambios = changed.map((a) => {
+    const art = a.curr ?? a.prev!
+    const base = { slug: art.slug, rawHeading: art.rawHeading || art.label }
+    if (a.status === 'modified' && a.prev && a.curr) {
+      const ops = wordDiff(a.prev.body, a.curr.body)
+        .filter((o) => o.op !== 'equal')
+        .map((o) => ({ op: o.op, text: joinDiffText(o.text).trim() }))
+        .filter((o) => o.text.length > 0)
+      return { ...base, estado: 'modificado' as const, ops }
+    }
+    if (a.status === 'added') {
+      return {
+        ...base, estado: 'añadido' as const,
+        body: art.body.slice(0, MAX_ADDED_BODY),
+        truncado: art.body.length > MAX_ADDED_BODY,
+      }
+    }
+    return { ...base, estado: 'eliminado' as const }
+  })
+
+  return jsonOk({
+    idNorma, from, to,
+    resumen: {
+      modificados: cambios.filter((c) => c.estado === 'modificado').length,
+      'añadidos': cambios.filter((c) => c.estado === 'añadido').length,
+      eliminados: cambios.filter((c) => c.estado === 'eliminado').length,
+    },
+    cambios,
+  }, 300)
+})
+```
+
+- [ ] **Step 4: Run the tests and make sure they pass**
+
+Run: `cd site && pnpm vitest run app/api/v1/normas/diff.route.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Run the whole suite and typecheck**
+
+Run: `cd site && pnpm vitest run && pnpm tsc --noEmit`
+Expected: all tests pass, typecheck clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add site/app/api/v1/normas
+git commit --no-gpg-sign -m "feat(api): structured diff between two versions
+
+The central question the corpus answers — how did this law read before
+the reform — returned as structured per-article insert/delete operations
+rather than rendered text, so callers present it however they like. The
+MCP server renders the same data as prose.
+
+An unchanged norma is an empty cambios array with a 200, not an error:
+'nothing changed' is a real answer."
+```
+
+---
+
+### Task 9: Apply the migration to production and document the API
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Create: `docs/api.md`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: no code.
+
+- [ ] **Step 1: Apply the migration to production**
+
+The site will 503 on every `/v1` call until `api_key` exists.
+
+```bash
+cd /home/pisanvs/code/ley-chile/.worktrees/public-api
+cat sql/006_api.sql | railway connect Postgres
+```
+
+Expected: `CREATE EXTENSION`, `CREATE TABLE` ×2, `CREATE INDEX` ×2, `CREATE FUNCTION` ×3.
+
+- [ ] **Step 2: Issue a key and verify the live endpoints**
+
+```bash
+echo "SELECT issue_api_key('smoke test');" | railway connect Postgres
+# then, with the printed token:
+KEY=lc_live_…
+curl -s -H "Authorization: Bearer $KEY" 'https://leyes.pisanvs.cl/v1/search?q=partidos+politicos' | head -c 400
+curl -s -H "Authorization: Bearer $KEY" 'https://leyes.pisanvs.cl/v1/normas/29994' | head -c 400
+curl -s -o /dev/null -w '%{http_code}\n' 'https://leyes.pisanvs.cl/v1/search?q=x'          # expect 401
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer nope" \
+  'https://leyes.pisanvs.cl/v1/search?q=x'                                                  # expect 401
+echo "SELECT endpoint, status, duration_ms FROM api_usage ORDER BY ts DESC LIMIT 5;" | railway connect Postgres
+```
+
+Expected: JSON bodies for the authenticated calls, `401` for both unauthenticated ones, and `api_usage` rows whose `endpoint` values are **templates** (`/v1/normas/{idNorma}`), never concrete paths.
+
+- [ ] **Step 3: Write the consumer documentation**
+
+Create `docs/api.md` covering: base URL `https://leyes.pisanvs.cl/v1`, the `Authorization: Bearer` header, every endpoint from the spec's table with one worked `curl` example and its JSON response, the error codes table, the note that `idNorma` is the stable identifier while `(tipo, numero)` is ambiguous, and a statement of what is logged (key, endpoint template, status, duration, timestamp), what is not (query text, IP, user-agent, concrete paths), and the 90-day retention.
+
+- [ ] **Step 4: Record the API in CLAUDE.md**
+
+Add to the **Railway SSR** section, after the **MCP server** paragraph:
+
+```markdown
+**Public REST API.** `site/app/api/v1/**` is a read-only JSON API at
+`https://leyes.pisanvs.cl/v1`, authenticated with `Authorization: Bearer
+lc_live_…`. Same data layer as the MCP server (`@/lib/norma`, `@/lib/search`);
+JSON rather than prose. Keys are issued with `SELECT issue_api_key('label')`
+and revoked with `SELECT revoke_api_key('lc_live_prefix')` — only the SHA-256
+digest is stored, so the plaintext is unrecoverable after issue. Usage is
+recorded per key in `api_usage`, storing the **route template** and never the
+concrete path, so the log cannot become a record of which laws a caller read;
+pruned at 90 days by `prune_api_usage()`. Schema: `sql/006_api.sql`. Spec:
+`docs/superpowers/specs/2026-09-08-public-api-design.md`.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/api.md CLAUDE.md
+git commit --no-gpg-sign -m "docs(api): consumer documentation for the public API
+
+Covers every endpoint with a worked curl example, the error codes, and
+why idNorma rather than (tipo, numero) is the stable identifier.
+
+States plainly what is logged — key, endpoint template, status,
+duration, timestamp — what is not (query text, IP, user-agent, concrete
+paths), and the 90-day retention. sql/001_schema.sql records that
+analytics.event collects no user dimension; this API introduces one for
+its consumers, and key holders should be able to read that rather than
+infer it."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** All eight MCP tools map to a task: `search_laws` and the citation lookup (Task 5), `search_articles` and `get_article` and `get_law` (Task 6), `list_versions`, `get_modifications`, `get_raw_link` (Task 7), `diff_versions` (Task 8). Auth (Task 2), usage with the template guarantee (Tasks 1, 3, 4), issuance and revocation and pruning (Task 1), 503-not-empty (Task 4), `private` caching (Task 4), retention (Task 1), the privacy-posture note (Task 9).
+
+**Type consistency.** `ApiKeyRecord {id, label}` is produced in Task 2 and consumed as `key.id` in Task 4. `RouteCtx.params` is a `Promise` in every route, matching Next 16. `parseIdNorma`/`parseFecha` are defined in Task 6 and used unchanged in Tasks 7 and 8. `NotFound`/`BadRequest` are defined in Task 4 and thrown in Tasks 5–8. `recordUsage(keyId, endpoint, status, durationMs)` has the same four-parameter shape in Tasks 3 and 4.
+
+**One gap accepted deliberately.** `getAvisos` and `getRefundido` are exposed by the MCP `get_law` tool but not by `/v1/normas/{idNorma}`. They are display concerns (LeyChile's own annotations and refundido pointers) rather than corpus data, and adding them is a small additive change if a consumer asks. Recorded here so it is a decision rather than an oversight.

--- a/docs/superpowers/specs/2026-09-08-public-api-design.md
+++ b/docs/superpowers/specs/2026-09-08-public-api-design.md
@@ -1,0 +1,225 @@
+# Public REST API — design
+
+**Status:** approved design, pending implementation
+**Date:** 2026-09-08
+
+## What this is
+
+A public, read-only HTTP JSON API over the Chilean legal corpus, covering the
+same ground as the MCP server at `/api/mcp`, authenticated with API keys that
+the operator provisions by hand, with per-key usage recorded for observability.
+
+## Why it is not a wrapper around MCP
+
+The MCP server returns **prose formatted for language models** — capped article
+bodies, human-readable citation lines, ambiguity notes. A REST client wants
+**structured JSON**. Wrapping one in the other would force every REST consumer
+to parse text that was shaped for an LLM's context window.
+
+`site/app/api/[transport]/route.ts` is already only a presentation layer: it
+imports `getNormaById`, `getArticlesAsOf`, `getVersions`, `getModifies`,
+`getModifiedBy`, `getOrganismosByIds` from `@/lib/norma` and `runSearch`,
+`searchArticles` from `@/lib/search`, then formats. The REST API is a second
+presentation layer over those same functions.
+
+```
+                 @/lib/norma  ·  @/lib/search
+                        │              │
+        ┌───────────────┴──────┬───────┴────────────┐
+        │                      │                    │
+   MCP  (prose)          REST /v1 (JSON)        site pages
+```
+
+Behaviour that must not diverge — the 12 KB article-body cap, the `idNorma`
+ambiguity handling, the as-of date semantics — belongs in the lib, so all three
+surfaces inherit it rather than reimplementing it.
+
+## Endpoints
+
+All under `/v1`, all `GET`, all requiring a key.
+
+| endpoint | returns |
+|---|---|
+| `/v1/search?q=&asOf=&limit=` | normas matching free text |
+| `/v1/search?tipo=&numero=` | normas matching a citation, all candidates |
+| `/v1/normas/{idNorma}` | metadata + article index, no bodies |
+| `/v1/normas/{idNorma}/articulos?fecha=&q=` | article index at a fecha; `q` searches **within** the norma and adds snippets |
+| `/v1/normas/{idNorma}/articulos/{slug}?fecha=` | one article body |
+| `/v1/normas/{idNorma}/versiones` | version history |
+| `/v1/normas/{idNorma}/diff?from=&to=` | structured diff between two versions |
+| `/v1/normas/{idNorma}/modificaciones` | what modified this norma, and what it modified |
+| `/v1/normas/{idNorma}/raw?fecha=` | canonical upstream leychile.cl link |
+
+### Why `idNorma` is the addressing primitive
+
+`(tipo, numero)` is **not unique**. There are several `DFL 1`, one per
+organismo, and the reader code already carries a hard-won comment: `/ley/20780`
+once resolved to a decreto whose `id_norma` happened to be 20780. Putting an
+ambiguous key in a public URL path would bake that bug into the contract.
+
+Citation-style access is served by `/v1/search?tipo=ley&numero=20780`, which
+returns every candidate with its `idNorma` and `organismo` so the caller can
+disambiguate deliberately rather than accidentally.
+
+### Coverage against the MCP tools
+
+| MCP tool | REST equivalent |
+|---|---|
+| `search_laws` | `GET /v1/search` |
+| `search_articles` | `GET /v1/normas/{idNorma}/articulos?q=` |
+| `get_law` | `GET /v1/normas/{idNorma}` |
+| `get_article` | `GET /v1/normas/{idNorma}/articulos/{slug}` |
+| `list_versions` | `GET /v1/normas/{idNorma}/versiones` |
+| `diff_versions` | `GET /v1/normas/{idNorma}/diff` |
+| `get_modifications` | `GET /v1/normas/{idNorma}/modificaciones` |
+| `get_raw_link` | `GET /v1/normas/{idNorma}/raw` |
+
+`search_articles` becomes a query parameter rather than its own path because it
+is a filter over the same collection the bare endpoint returns — with `q` the
+response carries `snippet` per article, without it the full index.
+
+### Field naming
+
+Spanish domain terms are kept: `titulo`, `numero`, `tipo`, `articulos`,
+`vigencia`, `organismo`. `norma`, `dfl` and `dto` have no honest English
+equivalents, and a half-translated schema is worse than an untranslated one.
+Structural fields that are not domain terms stay conventional (`limit`,
+`total`, `error`).
+
+## Authentication
+
+```
+Authorization: Bearer lc_live_<24 random bytes, base64url>
+```
+
+```sql
+CREATE TABLE api_key (
+  id         bigserial PRIMARY KEY,
+  key_hash   text NOT NULL UNIQUE,
+  key_prefix text NOT NULL,
+  label      text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  revoked_at timestamptz
+);
+```
+
+- **Only the SHA-256 of the key is stored.** The plaintext is returned once at
+  issue time and is unrecoverable afterwards. A database leak does not yield
+  usable keys.
+- `key_prefix` (e.g. `lc_live_a1b2c3d4`) exists solely so a human can tell keys
+  apart in a listing. It is not sufficient to authenticate.
+- Verification is one indexed probe on `key_hash` — constant work, no scan, and
+  no string-comparison timing channel, because an attacker cannot produce the
+  hash without already holding the key.
+- A key is valid when it exists and `revoked_at IS NULL`. Revocation is
+  `UPDATE api_key SET revoked_at = now() WHERE key_prefix = …`, effective on the
+  next request.
+
+### Provisioning
+
+```sql
+SELECT issue_api_key('Acme Corp');
+```
+
+Returns the plaintext key exactly once. Implemented with `pgcrypto`
+(`gen_random_bytes`), so it needs no local checkout, no environment, and works
+over `railway connect Postgres` — which matters, because this project currently
+has no public Postgres proxy.
+
+## Usage tracking
+
+```sql
+CREATE TABLE api_usage (
+  id          bigserial PRIMARY KEY,
+  key_id      bigint NOT NULL REFERENCES api_key(id) ON DELETE CASCADE,
+  ts          timestamptz NOT NULL DEFAULT now(),
+  endpoint    text NOT NULL,
+  status      int NOT NULL,
+  duration_ms int NOT NULL
+);
+CREATE INDEX api_usage_key_ts_idx ON api_usage (key_id, ts DESC);
+CREATE INDEX api_usage_ts_idx     ON api_usage (ts);
+```
+
+**`endpoint` stores the route template, never the concrete path** —
+`/v1/normas/{idNorma}/articulos/{slug}`, not `/v1/normas/29994/articulos/a3`.
+
+This is the load-bearing privacy decision, not an implementation detail.
+Recording concrete paths would build a per-person record of which laws someone
+read, which is the same category of data as the query text that was
+deliberately excluded. The template answers "who is calling what, how often, how
+fast, and is it erroring" and answers nothing about what anyone looked up.
+
+Recorded: key, endpoint template, status, duration, timestamp.
+Not recorded: query strings, path parameters, IP, user-agent, response bodies.
+
+The write is fire-and-forget — dispatched without `await`, errors swallowed and
+logged — so it adds no latency to the response. The site runs a **single
+persistent Node replica** (per `CLAUDE.md`), so the insert completes normally;
+this would not be safe on a serverless runtime that freezes after the response.
+The trade-off is that a crash can lose a few records. That is acceptable for
+observability and would **not** be acceptable if this metered billing.
+
+### Retention
+
+Pruned at 90 days, mirroring what `retier.py` already does for
+`analytics.event`. A `prune_api_usage(days => 90)` function ships with the
+schema; scheduling it is the loader's job.
+
+## Errors
+
+```json
+{ "error": { "code": "invalid_api_key", "message": "…" } }
+```
+
+| status | when |
+|---|---|
+| 400 | malformed `idNorma`, `fecha`, or missing required parameter |
+| 401 | missing, malformed, unknown, or revoked key |
+| 404 | no such norma, article, or version |
+| 503 | database unavailable |
+
+The 503 is deliberate and carries a lesson from the 2026-09-07 outage: a
+dependency failure must never be dressed as an empty successful result. An empty
+`results` array means "nothing matched"; it never means "the system is broken".
+
+## Caching
+
+`Cache-Control: private, max-age=300` plus an `ETag` on norma, article and
+version reads, which are immutable at a fixed `fecha`.
+
+`private`, not `public`: these responses sit behind an `Authorization` header
+and must never be stored by a shared cache. Search results are not cached — they
+depend on `asOf` and on ranking data that changes as the corpus is reloaded.
+
+## Testing
+
+- **Auth**: missing header, malformed header, wrong scheme, unknown key,
+  revoked key, valid key. A revoked key must fail *after* previously succeeding.
+- **Usage**: a row is written with the route template rather than the concrete
+  path — asserted explicitly, since that is the privacy guarantee; a failing
+  insert must not fail the request.
+- **Endpoints**: contract tests over a mocked `pool`, following the pattern in
+  `site/lib/search.resilience.test.ts`.
+- **Errors**: a database failure surfaces 503, never 200 with an empty list.
+
+## Deliberately out of scope
+
+- Rate limiting and quotas. Not needed until there is traffic to calibrate
+  against, and `api_usage` makes both straightforward to add later.
+- Key self-service, dashboards, billing.
+- Any write operation. The corpus is derived from `historial`; the API is
+  read-only by construction.
+- OpenAPI generation. Worth adding if consumers ask; not before.
+
+## Privacy posture — an explicit change
+
+`sql/001_schema.sql` records that `analytics.event` collects **no user
+dimension**. `api_key` and `api_usage` introduce one for API consumers: calls
+are attributable to an issued key, and therefore to whoever holds it.
+
+This is a deliberate and normal trade for an authenticated API, and it is
+scoped as narrowly as the requirement allows — no IP, no user-agent, no query
+text, no concrete paths, 90-day retention. It is recorded here rather than left
+implicit, and the terms shown to key holders should say what is logged and for
+how long.

--- a/site/app/api/v1/normas/[idNorma]/articulos/[slug]/route.ts
+++ b/site/app/api/v1/normas/[idNorma]/articulos/[slug]/route.ts
@@ -1,0 +1,31 @@
+import { getNormaById, getArticlesAsOf, getVersions, currentFecha } from '@/lib/norma'
+import { withApiKey, jsonOk, NotFound } from '@/lib/apiroute'
+import { parseIdNorma, parseFecha } from '@/lib/apiparams'
+
+/** Matches the cap the MCP server applies. A handful of articles in the corpus
+ *  are enormous; `truncado` tells the caller the text is incomplete rather than
+ *  letting them treat a cut-off article as the whole provision. */
+const MAX_BODY = 12_000
+
+export const GET = withApiKey('/v1/normas/{idNorma}/articulos/{slug}', async (req, ctx) => {
+  const params = await ctx.params
+  const idNorma = parseIdNorma(params.idNorma)
+  const slug = params.slug
+
+  const norma = await getNormaById(idNorma)
+  if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
+
+  const versions = await getVersions(idNorma)
+  const fecha = parseFecha(new URL(req.url).searchParams.get('fecha'), currentFecha(versions))
+  const articulos = await getArticlesAsOf(idNorma, fecha)
+  const art = articulos.find((a) => a.slug === slug)
+  if (!art) throw new NotFound(`No article "${slug}" in idNorma ${idNorma} as of ${fecha}`)
+
+  const truncado = art.body.length > MAX_BODY
+  return jsonOk({
+    idNorma, fecha, slug: art.slug, label: art.label, rawHeading: art.rawHeading,
+    body: truncado ? art.body.slice(0, MAX_BODY) : art.body,
+    truncado,
+    largoCompleto: art.body.length,
+  }, 300)
+})

--- a/site/app/api/v1/normas/[idNorma]/articulos/[slug]/route.ts
+++ b/site/app/api/v1/normas/[idNorma]/articulos/[slug]/route.ts
@@ -27,5 +27,5 @@ export const GET = withApiKey('/v1/normas/{idNorma}/articulos/{slug}', async (re
     body: truncado ? art.body.slice(0, MAX_BODY) : art.body,
     truncado,
     largoCompleto: art.body.length,
-  }, 300)
+  }, 300, req)
 })

--- a/site/app/api/v1/normas/[idNorma]/articulos/route.ts
+++ b/site/app/api/v1/normas/[idNorma]/articulos/route.ts
@@ -1,0 +1,36 @@
+import { getNormaById, getArticlesAsOf, getVersions, currentFecha } from '@/lib/norma'
+import { searchArticles } from '@/lib/search'
+import { withApiKey, jsonOk, NotFound } from '@/lib/apiroute'
+import { parseIdNorma, parseFecha } from '@/lib/apiparams'
+
+/** The article index at a fecha. With `q`, searches WITHIN the norma and
+ *  returns only matching articles, each with a snippet — the way to locate the
+ *  relevant article of a code with hundreds of them without pulling its text. */
+export const GET = withApiKey('/v1/normas/{idNorma}/articulos', async (req, ctx) => {
+  const idNorma = parseIdNorma((await ctx.params).idNorma)
+  const norma = await getNormaById(idNorma)
+  if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
+
+  const url = new URL(req.url)
+  const versions = await getVersions(idNorma)
+  const fecha = parseFecha(url.searchParams.get('fecha'), currentFecha(versions))
+  const q = url.searchParams.get('q')?.trim() ?? ''
+
+  if (q.length >= 2) {
+    const hits = await searchArticles(idNorma, q, fecha)
+    return jsonOk({
+      idNorma, fecha, query: q, total: hits.length,
+      articulos: hits.map((h) => ({
+        slug: h.slug, label: h.label, rawHeading: h.rawHeading, snippet: h.snippet,
+      })),
+    })
+  }
+
+  const articulos = await getArticlesAsOf(idNorma, fecha)
+  return jsonOk({
+    idNorma, fecha, total: articulos.length,
+    articulos: articulos.map((a) => ({
+      slug: a.slug, label: a.label, rawHeading: a.rawHeading,
+    })),
+  }, 300)
+})

--- a/site/app/api/v1/normas/[idNorma]/articulos/route.ts
+++ b/site/app/api/v1/normas/[idNorma]/articulos/route.ts
@@ -32,5 +32,5 @@ export const GET = withApiKey('/v1/normas/{idNorma}/articulos', async (req, ctx)
     articulos: articulos.map((a) => ({
       slug: a.slug, label: a.label, rawHeading: a.rawHeading,
     })),
-  }, 300)
+  }, 300, req)
 })

--- a/site/app/api/v1/normas/[idNorma]/diff/route.ts
+++ b/site/app/api/v1/normas/[idNorma]/diff/route.ts
@@ -19,8 +19,8 @@ export const GET = withApiKey('/v1/normas/{idNorma}/diff', async (req, ctx) => {
   if (!rawFrom || !rawTo) {
     throw new BadRequest('Both from and to are required (YYYY-MM-DD).')
   }
-  const from = parseFecha(rawFrom, rawFrom)
-  const to = parseFecha(rawTo, rawTo)
+  const from = parseFecha(rawFrom, '')
+  const to = parseFecha(rawTo, '')
 
   const norma = await getNormaById(idNorma)
   if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
@@ -63,5 +63,5 @@ export const GET = withApiKey('/v1/normas/{idNorma}/diff', async (req, ctx) => {
       eliminados: cambios.filter((c) => c.estado === 'eliminado').length,
     },
     cambios,
-  }, 300)
+  }, 300, req)
 })

--- a/site/app/api/v1/normas/[idNorma]/diff/route.ts
+++ b/site/app/api/v1/normas/[idNorma]/diff/route.ts
@@ -1,0 +1,67 @@
+import { getNormaById, getArticlesAsOf } from '@/lib/norma'
+import { align, wordDiff, joinDiffText } from '@/lib/diff'
+import { withApiKey, jsonOk, NotFound, BadRequest } from '@/lib/apiroute'
+import { parseIdNorma, parseFecha } from '@/lib/apiparams'
+
+const MAX_ADDED_BODY = 4_000
+
+/** What changed in a norma between two fechas.
+ *
+ *  This is the central question the corpus exists to answer — "how did this law
+ *  read before the reform?" — so the diff is returned structured rather than
+ *  rendered: callers get per-article insert/delete operations and can present
+ *  them however they like. The MCP server renders the same data as prose. */
+export const GET = withApiKey('/v1/normas/{idNorma}/diff', async (req, ctx) => {
+  const idNorma = parseIdNorma((await ctx.params).idNorma)
+  const url = new URL(req.url)
+  const rawFrom = url.searchParams.get('from')
+  const rawTo = url.searchParams.get('to')
+  if (!rawFrom || !rawTo) {
+    throw new BadRequest('Both from and to are required (YYYY-MM-DD).')
+  }
+  const from = parseFecha(rawFrom, rawFrom)
+  const to = parseFecha(rawTo, rawTo)
+
+  const norma = await getNormaById(idNorma)
+  if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
+
+  const [prev, curr] = await Promise.all([
+    getArticlesAsOf(idNorma, from),
+    getArticlesAsOf(idNorma, to),
+  ])
+  if (prev.length === 0 && curr.length === 0) {
+    throw new NotFound(`No text for idNorma ${idNorma} at either ${from} or ${to}`)
+  }
+
+  const changed = align(prev, curr).filter((a) => a.status !== 'unchanged')
+
+  const cambios = changed.map((a) => {
+    const art = a.curr ?? a.prev!
+    const base = { slug: art.slug, rawHeading: art.rawHeading || art.label }
+    if (a.status === 'modified' && a.prev && a.curr) {
+      const ops = wordDiff(a.prev.body, a.curr.body)
+        .filter((o) => o.op !== 'equal')
+        .map((o) => ({ op: o.op, text: joinDiffText(o.text).trim() }))
+        .filter((o) => o.text.length > 0)
+      return { ...base, estado: 'modificado' as const, ops }
+    }
+    if (a.status === 'added') {
+      return {
+        ...base, estado: 'añadido' as const,
+        body: art.body.slice(0, MAX_ADDED_BODY),
+        truncado: art.body.length > MAX_ADDED_BODY,
+      }
+    }
+    return { ...base, estado: 'eliminado' as const }
+  })
+
+  return jsonOk({
+    idNorma, from, to,
+    resumen: {
+      modificados: cambios.filter((c) => c.estado === 'modificado').length,
+      'añadidos': cambios.filter((c) => c.estado === 'añadido').length,
+      eliminados: cambios.filter((c) => c.estado === 'eliminado').length,
+    },
+    cambios,
+  }, 300)
+})

--- a/site/app/api/v1/normas/[idNorma]/modificaciones/route.ts
+++ b/site/app/api/v1/normas/[idNorma]/modificaciones/route.ts
@@ -7,7 +7,7 @@ import { parseIdNorma } from '@/lib/apiparams'
  *  Every entry carries `idNorma`, so a caller can address the related norma
  *  directly instead of resolving (tipo, numero) — which for a "DFL 4"
  *  reference is ambiguous many times over. */
-export const GET = withApiKey('/v1/normas/{idNorma}/modificaciones', async (_req, ctx) => {
+export const GET = withApiKey('/v1/normas/{idNorma}/modificaciones', async (req, ctx) => {
   const idNorma = parseIdNorma((await ctx.params).idNorma)
   const norma = await getNormaById(idNorma)
   if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
@@ -20,5 +20,5 @@ export const GET = withApiKey('/v1/normas/{idNorma}/modificaciones', async (_req
     idNorma: m.idNorma, tipo: m.tipo, numero: m.numero, titulo: m.titulo, fecha: m.fecha,
   })
 
-  return jsonOk({ idNorma, modifica: modifica.map(shape), modificadaPor: modificadaPor.map(shape) }, 300)
+  return jsonOk({ idNorma, modifica: modifica.map(shape), modificadaPor: modificadaPor.map(shape) }, 300, req)
 })

--- a/site/app/api/v1/normas/[idNorma]/modificaciones/route.ts
+++ b/site/app/api/v1/normas/[idNorma]/modificaciones/route.ts
@@ -1,0 +1,24 @@
+import { getNormaById, getModifies, getModifiedBy } from '@/lib/norma'
+import { withApiKey, jsonOk, NotFound } from '@/lib/apiroute'
+import { parseIdNorma } from '@/lib/apiparams'
+
+/** Both directions of the modification graph.
+ *
+ *  Every entry carries `idNorma`, so a caller can address the related norma
+ *  directly instead of resolving (tipo, numero) — which for a "DFL 4"
+ *  reference is ambiguous many times over. */
+export const GET = withApiKey('/v1/normas/{idNorma}/modificaciones', async (_req, ctx) => {
+  const idNorma = parseIdNorma((await ctx.params).idNorma)
+  const norma = await getNormaById(idNorma)
+  if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
+
+  const [modifica, modificadaPor] = await Promise.all([
+    getModifies(idNorma),
+    getModifiedBy(idNorma),
+  ])
+  const shape = (m: { idNorma: number; tipo: string; numero: string; titulo: string; fecha: string }) => ({
+    idNorma: m.idNorma, tipo: m.tipo, numero: m.numero, titulo: m.titulo, fecha: m.fecha,
+  })
+
+  return jsonOk({ idNorma, modifica: modifica.map(shape), modificadaPor: modificadaPor.map(shape) }, 300)
+})

--- a/site/app/api/v1/normas/[idNorma]/raw/route.ts
+++ b/site/app/api/v1/normas/[idNorma]/raw/route.ts
@@ -1,0 +1,21 @@
+import { getNormaById, getVersions, currentFecha } from '@/lib/norma'
+import { withApiKey, jsonOk, NotFound } from '@/lib/apiroute'
+import { parseIdNorma, parseFecha } from '@/lib/apiparams'
+
+/** The canonical leychile.cl URL for one version — the authoritative source
+ *  this corpus is derived from, for anyone who needs to cite or verify it. */
+export const GET = withApiKey('/v1/normas/{idNorma}/raw', async (req, ctx) => {
+  const idNorma = parseIdNorma((await ctx.params).idNorma)
+  const norma = await getNormaById(idNorma)
+  if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
+
+  const versions = await getVersions(idNorma)
+  const fecha = parseFecha(new URL(req.url).searchParams.get('fecha'), currentFecha(versions))
+
+  return jsonOk({
+    idNorma,
+    fecha,
+    url: `https://www.leychile.cl/Navegar?idNorma=${idNorma}&idVersion=${fecha}`,
+    xml: `https://www.leychile.cl/Consulta/obtxml?opt=7&idNorma=${idNorma}&idVersion=${fecha}`,
+  }, 300)
+})

--- a/site/app/api/v1/normas/[idNorma]/raw/route.ts
+++ b/site/app/api/v1/normas/[idNorma]/raw/route.ts
@@ -17,5 +17,5 @@ export const GET = withApiKey('/v1/normas/{idNorma}/raw', async (req, ctx) => {
     fecha,
     url: `https://www.leychile.cl/Navegar?idNorma=${idNorma}&idVersion=${fecha}`,
     xml: `https://www.leychile.cl/Consulta/obtxml?opt=7&idNorma=${idNorma}&idVersion=${fecha}`,
-  }, 300)
+  }, 300, req)
 })

--- a/site/app/api/v1/normas/[idNorma]/route.ts
+++ b/site/app/api/v1/normas/[idNorma]/route.ts
@@ -29,5 +29,5 @@ export const GET = withApiKey('/v1/normas/{idNorma}', async (req, ctx) => {
     articulos: articulos.map((a) => ({
       slug: a.slug, label: a.label, rawHeading: a.rawHeading,
     })),
-  }, 300)
+  }, 300, req)
 })

--- a/site/app/api/v1/normas/[idNorma]/route.ts
+++ b/site/app/api/v1/normas/[idNorma]/route.ts
@@ -1,0 +1,33 @@
+import { getNormaById, getArticlesAsOf, getVersions, currentFecha } from '@/lib/norma'
+import { withApiKey, jsonOk, NotFound } from '@/lib/apiroute'
+import { parseIdNorma, parseFecha } from '@/lib/apiparams'
+
+/** Metadata plus an article INDEX — never article bodies.
+ *
+ *  One norma can be ~350 KB of text. Returning it whole would make the common
+ *  case (identify a law, then read one article) pay for the rare one. Bodies
+ *  come from /articulos/{slug}, one at a time. */
+export const GET = withApiKey('/v1/normas/{idNorma}', async (req, ctx) => {
+  const idNorma = parseIdNorma((await ctx.params).idNorma)
+  const norma = await getNormaById(idNorma)
+  if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
+
+  const versions = await getVersions(idNorma)
+  const fecha = parseFecha(new URL(req.url).searchParams.get('fecha'), currentFecha(versions))
+  const articulos = await getArticlesAsOf(idNorma, fecha)
+
+  return jsonOk({
+    idNorma: norma.idNorma,
+    tipo: norma.tipo,
+    numero: norma.numero,
+    titulo: norma.titulo,
+    organismo: norma.organismo,
+    derogado: norma.derogado,
+    fechaPublicacion: norma.fechaPublicacion,
+    fecha,
+    totalVersiones: versions.length,
+    articulos: articulos.map((a) => ({
+      slug: a.slug, label: a.label, rawHeading: a.rawHeading,
+    })),
+  }, 300)
+})

--- a/site/app/api/v1/normas/[idNorma]/versiones/route.ts
+++ b/site/app/api/v1/normas/[idNorma]/versiones/route.ts
@@ -1,0 +1,21 @@
+import { getNormaById, getVersions, currentFecha } from '@/lib/norma'
+import { withApiKey, jsonOk, NotFound } from '@/lib/apiroute'
+import { parseIdNorma } from '@/lib/apiparams'
+
+/** Every version of a norma with its validity window. `desde`/`hasta` are the
+ *  fechas to pass to the article and diff endpoints. */
+export const GET = withApiKey('/v1/normas/{idNorma}/versiones', async (_req, ctx) => {
+  const idNorma = parseIdNorma((await ctx.params).idNorma)
+  const norma = await getNormaById(idNorma)
+  if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
+
+  const versions = await getVersions(idNorma)
+  return jsonOk({
+    idNorma,
+    vigente: currentFecha(versions),
+    total: versions.length,
+    versiones: versions.map((v) => ({
+      desde: v.desde, hasta: v.hasta, causaId: v.causaId, subject: v.subject,
+    })),
+  }, 300)
+})

--- a/site/app/api/v1/normas/[idNorma]/versiones/route.ts
+++ b/site/app/api/v1/normas/[idNorma]/versiones/route.ts
@@ -4,7 +4,7 @@ import { parseIdNorma } from '@/lib/apiparams'
 
 /** Every version of a norma with its validity window. `desde`/`hasta` are the
  *  fechas to pass to the article and diff endpoints. */
-export const GET = withApiKey('/v1/normas/{idNorma}/versiones', async (_req, ctx) => {
+export const GET = withApiKey('/v1/normas/{idNorma}/versiones', async (req, ctx) => {
   const idNorma = parseIdNorma((await ctx.params).idNorma)
   const norma = await getNormaById(idNorma)
   if (!norma) throw new NotFound(`No norma with idNorma ${idNorma}`)
@@ -17,5 +17,5 @@ export const GET = withApiKey('/v1/normas/{idNorma}/versiones', async (_req, ctx
     versiones: versions.map((v) => ({
       desde: v.desde, hasta: v.hasta, causaId: v.causaId, subject: v.subject,
     })),
-  }, 300)
+  }, 300, req)
 })

--- a/site/app/api/v1/normas/diff.route.test.ts
+++ b/site/app/api/v1/normas/diff.route.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getNormaById = vi.fn()
+const getArticlesAsOf = vi.fn()
+vi.mock('@/lib/norma', () => ({ getNormaById, getArticlesAsOf }))
+vi.mock('@/lib/apikey', () => ({ verifyApiKey: vi.fn().mockResolvedValue({ id: 1, label: 'T' }) }))
+vi.mock('@/lib/apiusage', () => ({ recordUsage: vi.fn().mockResolvedValue(undefined) }))
+
+const NORMA = {
+  idNorma: 29994, tipo: 'ley', numero: '18603', titulo: 'LOC PARTIDOS',
+  organismo: 'INTERIOR', derogado: false, fechaPublicacion: '1987-03-11', lawDir: 'leyes/18603',
+}
+const art = (slug: string, body: string) => ({
+  slug, label: `Artículo ${slug}`, rawHeading: `Artículo ${slug}`, body, ord: 0,
+})
+
+beforeEach(() => {
+  vi.resetModules()
+  getNormaById.mockReset().mockResolvedValue(NORMA)
+  getArticlesAsOf.mockReset()
+})
+
+const H = { headers: { authorization: 'Bearer lc_live_x' } }
+const P = { params: Promise.resolve({ idNorma: '29994' }) }
+const call = async (qs: string) => {
+  const { GET } = await import('./[idNorma]/diff/route')
+  return GET(new Request(`https://x/v1/normas/29994/diff?${qs}`, H), P)
+}
+
+describe('GET /v1/normas/{idNorma}/diff', () => {
+  it('reports modified, added and removed articles', async () => {
+    getArticlesAsOf
+      .mockResolvedValueOnce([art('a1', 'el plazo es de 30 dias'), art('a2', 'se elimina')])
+      .mockResolvedValueOnce([art('a1', 'el plazo es de 60 dias'), art('a3', 'nuevo')])
+    const res = await call('from=2010-01-01&to=2020-01-01')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.resumen).toEqual({ modificados: 1, añadidos: 1, eliminados: 1 })
+    const mod = body.cambios.find((c: { estado: string }) => c.estado === 'modificado')
+    expect(mod.slug).toBe('a1')
+    expect(JSON.stringify(mod.ops)).toContain('60')
+  })
+
+  it('returns an empty change set when nothing changed, not an error', async () => {
+    getArticlesAsOf
+      .mockResolvedValueOnce([art('a1', 'igual')])
+      .mockResolvedValueOnce([art('a1', 'igual')])
+    const res = await call('from=2010-01-01&to=2020-01-01')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.cambios).toEqual([])
+    expect(body.resumen).toEqual({ modificados: 0, añadidos: 0, eliminados: 0 })
+  })
+
+  it('400s when from or to is missing', async () => {
+    expect((await call('from=2010-01-01')).status).toBe(400)
+    expect((await call('to=2020-01-01')).status).toBe(400)
+  })
+
+  it('404s when neither fecha has any text', async () => {
+    getArticlesAsOf.mockResolvedValue([])
+    expect((await call('from=1800-01-01&to=1801-01-01')).status).toBe(404)
+  })
+})

--- a/site/app/api/v1/normas/normas.route.test.ts
+++ b/site/app/api/v1/normas/normas.route.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getNormaById = vi.fn()
+const getArticlesAsOf = vi.fn()
+const getVersions = vi.fn()
+const currentFecha = vi.fn()
+const searchArticles = vi.fn()
+vi.mock('@/lib/norma', () => ({ getNormaById, getArticlesAsOf, getVersions, currentFecha }))
+vi.mock('@/lib/search', () => ({ searchArticles }))
+vi.mock('@/lib/apikey', () => ({ verifyApiKey: vi.fn().mockResolvedValue({ id: 1, label: 'T' }) }))
+vi.mock('@/lib/apiusage', () => ({ recordUsage: vi.fn().mockResolvedValue(undefined) }))
+
+const NORMA = {
+  idNorma: 29994, tipo: 'ley', numero: '18603', titulo: 'LOC PARTIDOS',
+  organismo: 'INTERIOR', derogado: false, fechaPublicacion: '1987-03-11', lawDir: 'leyes/18603',
+}
+const ART = { slug: 'a1', label: 'Artículo 1', rawHeading: 'Artículo 1º', body: 'Cuerpo.', ord: 0 }
+
+beforeEach(() => {
+  vi.resetModules()
+  for (const m of [getNormaById, getArticlesAsOf, getVersions, currentFecha, searchArticles]) m.mockReset()
+  getNormaById.mockResolvedValue(NORMA)
+  getVersions.mockResolvedValue([{ desde: '1987-03-11', hasta: null, commitSha: 'a', causaId: null, subject: 's' }])
+  currentFecha.mockReturnValue('1987-03-11')
+  getArticlesAsOf.mockResolvedValue([ART])
+})
+
+const H = { headers: { authorization: 'Bearer lc_live_x' } }
+
+describe('GET /v1/normas/{idNorma}', () => {
+  it('returns metadata and an article index without bodies', async () => {
+    // A single norma can be ~350KB. The index lists articles; bodies are
+    // fetched one at a time.
+    const { GET } = await import('./[idNorma]/route')
+    const res = await GET(new Request('https://x/v1/normas/29994', H),
+      { params: Promise.resolve({ idNorma: '29994' }) })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.titulo).toBe('LOC PARTIDOS')
+    expect(body.articulos).toEqual([{ slug: 'a1', label: 'Artículo 1', rawHeading: 'Artículo 1º' }])
+    expect(JSON.stringify(body)).not.toContain('Cuerpo.')
+  })
+
+  it('404s for an unknown norma', async () => {
+    getNormaById.mockResolvedValue(null)
+    const { GET } = await import('./[idNorma]/route')
+    const res = await GET(new Request('https://x/v1/normas/1', H),
+      { params: Promise.resolve({ idNorma: '1' }) })
+    expect(res.status).toBe(404)
+  })
+
+  it('400s on a non-numeric idNorma', async () => {
+    const { GET } = await import('./[idNorma]/route')
+    const res = await GET(new Request('https://x/v1/normas/abc', H),
+      { params: Promise.resolve({ idNorma: 'abc' }) })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('GET /v1/normas/{idNorma}/articulos', () => {
+  it('lists the article index at a fecha', async () => {
+    const { GET } = await import('./[idNorma]/articulos/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/articulos?fecha=2020-01-01', H),
+      { params: Promise.resolve({ idNorma: '29994' }) })
+    expect(res.status).toBe(200)
+    expect(getArticlesAsOf).toHaveBeenCalledWith(29994, '2020-01-01')
+    expect((await res.json()).articulos[0].slug).toBe('a1')
+  })
+
+  it('adds snippets and drops non-matching articles when q is given', async () => {
+    searchArticles.mockResolvedValue([
+      { slug: 'a1', label: 'Artículo 1', rawHeading: 'Artículo 1º', snippet: '…<b>cuerpo</b>…' },
+    ])
+    const { GET } = await import('./[idNorma]/articulos/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/articulos?q=cuerpo', H),
+      { params: Promise.resolve({ idNorma: '29994' }) })
+    const body = await res.json()
+    expect(searchArticles).toHaveBeenCalled()
+    expect(body.articulos[0].snippet).toContain('cuerpo')
+  })
+})
+
+describe('GET /v1/normas/{idNorma}/articulos/{slug}', () => {
+  it('returns one article body', async () => {
+    const { GET } = await import('./[idNorma]/articulos/[slug]/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/articulos/a1', H),
+      { params: Promise.resolve({ idNorma: '29994', slug: 'a1' }) })
+    expect(res.status).toBe(200)
+    expect((await res.json()).body).toBe('Cuerpo.')
+  })
+
+  it('404s for a slug that is not in this norma', async () => {
+    const { GET } = await import('./[idNorma]/articulos/[slug]/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/articulos/zz', H),
+      { params: Promise.resolve({ idNorma: '29994', slug: 'zz' }) })
+    expect(res.status).toBe(404)
+  })
+
+  it('truncates a very long body and says so', async () => {
+    getArticlesAsOf.mockResolvedValue([{ ...ART, body: 'x'.repeat(20_000) }])
+    const { GET } = await import('./[idNorma]/articulos/[slug]/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/articulos/a1', H),
+      { params: Promise.resolve({ idNorma: '29994', slug: 'a1' }) })
+    const body = await res.json()
+    expect(body.body.length).toBeLessThan(20_000)
+    expect(body.truncado).toBe(true)
+  })
+})

--- a/site/app/api/v1/normas/relations.route.test.ts
+++ b/site/app/api/v1/normas/relations.route.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getNormaById = vi.fn()
+const getVersions = vi.fn()
+const getModifies = vi.fn()
+const getModifiedBy = vi.fn()
+const currentFecha = vi.fn()
+vi.mock('@/lib/norma', () => ({ getNormaById, getVersions, getModifies, getModifiedBy, currentFecha }))
+vi.mock('@/lib/apikey', () => ({ verifyApiKey: vi.fn().mockResolvedValue({ id: 1, label: 'T' }) }))
+vi.mock('@/lib/apiusage', () => ({ recordUsage: vi.fn().mockResolvedValue(undefined) }))
+
+const NORMA = {
+  idNorma: 29994, tipo: 'ley', numero: '18603', titulo: 'LOC PARTIDOS',
+  organismo: 'INTERIOR', derogado: false, fechaPublicacion: '1987-03-11', lawDir: 'leyes/18603',
+}
+const MOD = { idNorma: 242302, tipo: 'ley', numero: '20500', titulo: 'ASOCIACIONES', fecha: '2011-02-16' }
+
+beforeEach(() => {
+  vi.resetModules()
+  for (const m of [getNormaById, getVersions, getModifies, getModifiedBy, currentFecha]) m.mockReset()
+  getNormaById.mockResolvedValue(NORMA)
+  getVersions.mockResolvedValue([
+    { desde: '1987-03-11', hasta: '2011-02-15', commitSha: 'a', causaId: null, subject: 'orig' },
+    { desde: '2011-02-16', hasta: null, commitSha: 'b', causaId: 242302, subject: 'reforma' },
+  ])
+  currentFecha.mockReturnValue('2011-02-16')
+  getModifies.mockResolvedValue([])
+  getModifiedBy.mockResolvedValue([MOD])
+})
+
+const H = { headers: { authorization: 'Bearer lc_live_x' } }
+const P = { params: Promise.resolve({ idNorma: '29994' }) }
+
+describe('GET /v1/normas/{idNorma}/versiones', () => {
+  it('lists every version with its validity window', async () => {
+    const { GET } = await import('./[idNorma]/versiones/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/versiones', H), P)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.total).toBe(2)
+    expect(body.versiones[0]).toMatchObject({ desde: '1987-03-11', hasta: '2011-02-15' })
+    expect(body.vigente).toBe('2011-02-16')
+  })
+
+  it('404s for an unknown norma', async () => {
+    getNormaById.mockResolvedValue(null)
+    const { GET } = await import('./[idNorma]/versiones/route')
+    expect((await GET(new Request('https://x/v1/normas/29994/versiones', H), P)).status).toBe(404)
+  })
+})
+
+describe('GET /v1/normas/{idNorma}/modificaciones', () => {
+  it('returns both directions, each carrying idNorma', async () => {
+    // Without idNorma a caller would have to resolve (tipo, numero), which for
+    // a "DFL 4" reference is ambiguous many times over.
+    const { GET } = await import('./[idNorma]/modificaciones/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/modificaciones', H), P)
+    const body = await res.json()
+    expect(body.modificadaPor[0].idNorma).toBe(242302)
+    expect(body.modifica).toEqual([])
+  })
+})
+
+describe('GET /v1/normas/{idNorma}/raw', () => {
+  it('returns the canonical upstream link for a fecha', async () => {
+    const { GET } = await import('./[idNorma]/raw/route')
+    const res = await GET(new Request('https://x/v1/normas/29994/raw?fecha=2011-02-16', H), P)
+    const body = await res.json()
+    expect(body.url).toContain('leychile.cl')
+    expect(body.url).toContain('29994')
+    expect(body.fecha).toBe('2011-02-16')
+  })
+})

--- a/site/app/api/v1/search/route.test.ts
+++ b/site/app/api/v1/search/route.test.ts
@@ -65,7 +65,22 @@ describe('GET /v1/search', () => {
 
   it('caps limit so one call cannot ask for the whole corpus', async () => {
     runSearch.mockResolvedValue([])
-    await call('q=x&limit=9999')
+    await call('q=xy&limit=9999')
     expect(runSearch.mock.calls[0][2]).toBe(100)
+  })
+
+  it('never truncates citation candidates, even when limit is given', async () => {
+    // limit is a free-text-search concept only. Applying it to the citation
+    // branch would silently drop candidates — exactly what idNorma addressing
+    // exists to prevent. getNormasByKey deliberately takes no limit param.
+    getNormasByKey.mockResolvedValue([
+      { ...HIT, idNorma: 1, tipo: 'dfl', numero: '1', organismo: 'TRABAJO' },
+      { ...HIT, idNorma: 2, tipo: 'dfl', numero: '1', organismo: 'SALUD' },
+      { ...HIT, idNorma: 3, tipo: 'dfl', numero: '1', organismo: 'EDUCACION' },
+    ])
+    const res = await call('tipo=dfl&numero=1&limit=1')
+    const body = await res.json()
+    expect(body.total).toBe(3)
+    expect(body.resultados.map((r: { idNorma: number }) => r.idNorma)).toEqual([1, 2, 3])
   })
 })

--- a/site/app/api/v1/search/route.test.ts
+++ b/site/app/api/v1/search/route.test.ts
@@ -63,6 +63,13 @@ describe('GET /v1/search', () => {
     expect(res.status).toBe(400)
   })
 
+  it('rejects an asOf that is not a real calendar date', async () => {
+    // 2026-02-31 matches YYYY-MM-DD but does not exist. A regex-only check
+    // would let it through; parseFecha's calendar round-trip must not.
+    const res = await call('q=x&asOf=2026-02-31')
+    expect(res.status).toBe(400)
+  })
+
   it('caps limit so one call cannot ask for the whole corpus', async () => {
     runSearch.mockResolvedValue([])
     await call('q=xy&limit=9999')

--- a/site/app/api/v1/search/route.test.ts
+++ b/site/app/api/v1/search/route.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const runSearch = vi.fn()
+const getNormasByKey = vi.fn()
+const getOrganismosByIds = vi.fn()
+vi.mock('@/lib/search', () => ({ runSearch }))
+vi.mock('@/lib/norma', () => ({ getNormasByKey, getOrganismosByIds }))
+vi.mock('@/lib/apikey', () => ({ verifyApiKey: vi.fn().mockResolvedValue({ id: 1, label: 'T' }) }))
+vi.mock('@/lib/apiusage', () => ({ recordUsage: vi.fn().mockResolvedValue(undefined) }))
+
+beforeEach(() => {
+  vi.resetModules()
+  runSearch.mockReset()
+  getNormasByKey.mockReset()
+  getOrganismosByIds.mockReset().mockResolvedValue(new Map([[29994, 'MINISTERIO DEL INTERIOR']]))
+})
+
+const CTX = { params: Promise.resolve({}) }
+const call = async (qs: string) => {
+  const { GET } = await import('./route')
+  return GET(new Request(`https://x/v1/search?${qs}`, {
+    headers: { authorization: 'Bearer lc_live_x' },
+  }), CTX)
+}
+
+const HIT = { idNorma: 29994, tipo: 'ley', numero: '18603', titulo: 'LOC DE LOS PARTIDOS POLITICOS' }
+
+describe('GET /v1/search', () => {
+  it('returns free-text results enriched with organismo', async () => {
+    runSearch.mockResolvedValue([HIT])
+    const res = await call('q=partidos')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.total).toBe(1)
+    expect(body.resultados[0]).toEqual({
+      idNorma: 29994, tipo: 'ley', numero: '18603',
+      titulo: 'LOC DE LOS PARTIDOS POLITICOS', organismo: 'MINISTERIO DEL INTERIOR',
+    })
+  })
+
+  it('400s when neither q nor a tipo/numero pair is given', async () => {
+    const res = await call('')
+    expect(res.status).toBe(400)
+    expect((await res.json()).error.code).toBe('bad_request')
+  })
+
+  it('resolves a citation to every candidate, since (tipo, numero) is ambiguous', async () => {
+    // Several DFL 1 exist, one per organismo. Returning one of them silently
+    // would be the /ley/20780 bug all over again.
+    getNormasByKey.mockResolvedValue([
+      { ...HIT, idNorma: 1, tipo: 'dfl', numero: '1', organismo: 'TRABAJO' },
+      { ...HIT, idNorma: 2, tipo: 'dfl', numero: '1', organismo: 'SALUD' },
+    ])
+    const res = await call('tipo=dfl&numero=1')
+    const body = await res.json()
+    expect(body.total).toBe(2)
+    expect(body.resultados.map((r: { idNorma: number }) => r.idNorma)).toEqual([1, 2])
+    expect(runSearch).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed asOf rather than silently searching today', async () => {
+    const res = await call('q=x&asOf=ayer')
+    expect(res.status).toBe(400)
+  })
+
+  it('caps limit so one call cannot ask for the whole corpus', async () => {
+    runSearch.mockResolvedValue([])
+    await call('q=x&limit=9999')
+    expect(runSearch.mock.calls[0][2]).toBe(100)
+  })
+})

--- a/site/app/api/v1/search/route.ts
+++ b/site/app/api/v1/search/route.ts
@@ -1,9 +1,9 @@
 import { runSearch } from '@/lib/search'
 import { getNormasByKey, getOrganismosByIds } from '@/lib/norma'
 import { withApiKey, jsonOk, BadRequest } from '@/lib/apiroute'
+import { parseFecha } from '@/lib/apiparams'
 
 const MAX_LIMIT = 100
-const FECHA_RE = /^\d{4}-\d{2}-\d{2}$/
 
 interface Result {
   idNorma: number
@@ -25,11 +25,7 @@ export const GET = withApiKey('/v1/search', async (req) => {
   const q = url.searchParams.get('q')?.trim() ?? ''
   const tipo = url.searchParams.get('tipo')?.trim() ?? ''
   const numero = url.searchParams.get('numero')?.trim() ?? ''
-  const asOf = url.searchParams.get('asOf') ?? new Date().toISOString().slice(0, 10)
-
-  if (!FECHA_RE.test(asOf)) {
-    throw new BadRequest(`asOf must be YYYY-MM-DD, got "${asOf}"`)
-  }
+  const asOf = parseFecha(url.searchParams.get('asOf'), new Date().toISOString().slice(0, 10))
 
   const rawLimit = Number(url.searchParams.get('limit') ?? 20)
   const limit = Number.isFinite(rawLimit)

--- a/site/app/api/v1/search/route.ts
+++ b/site/app/api/v1/search/route.ts
@@ -39,12 +39,15 @@ export const GET = withApiKey('/v1/search', async (req) => {
   let resultados: Result[]
 
   if (tipo && numero) {
+    // No `limit` here: a citation returns EVERY candidate, never a truncated
+    // best guess (see the doc comment above) — `getNormasByKey` deliberately
+    // takes no limit parameter either.
     const normas = await getNormasByKey(tipo, numero)
-    resultados = normas.slice(0, limit).map((n) => ({
+    resultados = normas.map((n) => ({
       idNorma: n.idNorma, tipo: n.tipo, numero: n.numero,
       titulo: n.titulo, organismo: n.organismo,
     }))
-  } else if (q.length >= 1) {
+  } else if (q.length >= 2) {
     const hits = await runSearch(q, asOf, limit)
     const orgs = await getOrganismosByIds(hits.map((h) => h.idNorma))
     resultados = hits.map((h) => ({
@@ -53,7 +56,7 @@ export const GET = withApiKey('/v1/search', async (req) => {
     }))
   } else {
     throw new BadRequest(
-      'Provide q for free-text search, or tipo and numero for a citation.',
+      'Provide q (at least 2 characters) for free-text search, or tipo and numero for a citation.',
     )
   }
 

--- a/site/app/api/v1/search/route.ts
+++ b/site/app/api/v1/search/route.ts
@@ -1,0 +1,61 @@
+import { runSearch } from '@/lib/search'
+import { getNormasByKey, getOrganismosByIds } from '@/lib/norma'
+import { withApiKey, jsonOk, BadRequest } from '@/lib/apiroute'
+
+const MAX_LIMIT = 100
+const FECHA_RE = /^\d{4}-\d{2}-\d{2}$/
+
+interface Result {
+  idNorma: number
+  tipo: string
+  numero: string
+  titulo: string
+  organismo: string
+}
+
+/** Search the corpus, either by free text (`q`) or by citation
+ *  (`tipo` + `numero`).
+ *
+ *  A citation returns EVERY candidate rather than a best guess: (tipo, numero)
+ *  is not unique — there are many "DFL 1", one per organismo — and picking one
+ *  silently is how /ley/20780 once resolved to an unrelated decreto. Callers
+ *  disambiguate on `idNorma`, which is unique. */
+export const GET = withApiKey('/v1/search', async (req) => {
+  const url = new URL(req.url)
+  const q = url.searchParams.get('q')?.trim() ?? ''
+  const tipo = url.searchParams.get('tipo')?.trim() ?? ''
+  const numero = url.searchParams.get('numero')?.trim() ?? ''
+  const asOf = url.searchParams.get('asOf') ?? new Date().toISOString().slice(0, 10)
+
+  if (!FECHA_RE.test(asOf)) {
+    throw new BadRequest(`asOf must be YYYY-MM-DD, got "${asOf}"`)
+  }
+
+  const rawLimit = Number(url.searchParams.get('limit') ?? 20)
+  const limit = Number.isFinite(rawLimit)
+    ? Math.min(Math.max(Math.trunc(rawLimit), 1), MAX_LIMIT)
+    : 20
+
+  let resultados: Result[]
+
+  if (tipo && numero) {
+    const normas = await getNormasByKey(tipo, numero)
+    resultados = normas.slice(0, limit).map((n) => ({
+      idNorma: n.idNorma, tipo: n.tipo, numero: n.numero,
+      titulo: n.titulo, organismo: n.organismo,
+    }))
+  } else if (q.length >= 1) {
+    const hits = await runSearch(q, asOf, limit)
+    const orgs = await getOrganismosByIds(hits.map((h) => h.idNorma))
+    resultados = hits.map((h) => ({
+      idNorma: h.idNorma, tipo: h.tipo, numero: h.numero,
+      titulo: h.titulo, organismo: orgs.get(h.idNorma) ?? '',
+    }))
+  } else {
+    throw new BadRequest(
+      'Provide q for free-text search, or tipo and numero for a citation.',
+    )
+  }
+
+  return jsonOk({ query: q || `${tipo} ${numero}`.trim(), asOf, total: resultados.length, resultados })
+})

--- a/site/lib/apikey.test.ts
+++ b/site/lib/apikey.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const query = vi.fn()
+vi.mock('./db', () => ({ pool: { query } }))
+
+beforeEach(() => {
+  vi.resetModules()
+  query.mockReset()
+})
+
+const ROW = { id: 7, label: 'Acme Corp' }
+
+describe('verifyApiKey', () => {
+  it('accepts a live key and returns its identity', async () => {
+    query.mockResolvedValue({ rows: [ROW] })
+    const { verifyApiKey } = await import('./apikey')
+    expect(await verifyApiKey('lc_live_abc')).toEqual(ROW)
+  })
+
+  it('looks the key up by SHA-256 digest, never by the plaintext', async () => {
+    // The plaintext must not appear in any query parameter — a query log or an
+    // error trace would otherwise leak usable credentials.
+    query.mockResolvedValue({ rows: [ROW] })
+    const { verifyApiKey } = await import('./apikey')
+    await verifyApiKey('lc_live_abc')
+    const params = query.mock.calls[0][1] as string[]
+    expect(params).toHaveLength(1)
+    expect(params[0]).not.toContain('lc_live_abc')
+    expect(params[0]).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('rejects an unknown key', async () => {
+    query.mockResolvedValue({ rows: [] })
+    const { verifyApiKey } = await import('./apikey')
+    expect(await verifyApiKey('lc_live_nope')).toBeNull()
+  })
+
+  it('rejects an empty token without touching the database', async () => {
+    const { verifyApiKey } = await import('./apikey')
+    expect(await verifyApiKey('')).toBeNull()
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('filters revoked keys in SQL rather than in the caller', async () => {
+    query.mockResolvedValue({ rows: [] })
+    const { verifyApiKey } = await import('./apikey')
+    await verifyApiKey('lc_live_abc')
+    expect(String(query.mock.calls[0][0])).toMatch(/revoked_at IS NULL/)
+  })
+})

--- a/site/lib/apikey.ts
+++ b/site/lib/apikey.ts
@@ -1,0 +1,27 @@
+import { createHash } from 'node:crypto'
+import { pool } from './db'
+
+export interface ApiKeyRecord {
+  id: number
+  label: string
+}
+
+/** Verify a bearer token against `api_key`.
+ *
+ *  Only the SHA-256 digest is ever sent to the database, so the plaintext
+ *  cannot leak through a query log or an error trace. The digest is the unique
+ *  key, making this one indexed probe with no scan — and no string-comparison
+ *  timing channel, since an attacker cannot produce the digest without already
+ *  holding the token.
+ *
+ *  Revocation is filtered in SQL: a caller that forgets to check a flag is a
+ *  security bug, so there is no flag to forget. */
+export async function verifyApiKey(token: string): Promise<ApiKeyRecord | null> {
+  if (!token) return null
+  const hash = createHash('sha256').update(token).digest('hex')
+  const { rows } = await pool.query(
+    `SELECT id, label FROM api_key WHERE key_hash = $1 AND revoked_at IS NULL`,
+    [hash],
+  )
+  return rows.length ? { id: rows[0].id as number, label: rows[0].label as string } : null
+}

--- a/site/lib/apiparams.test.ts
+++ b/site/lib/apiparams.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { parseIdNorma, parseFecha } from './apiparams'
+import { BadRequest } from './apiroute'
+
+describe('parseIdNorma', () => {
+  it('accepts a positive integer', () => {
+    expect(parseIdNorma('29994')).toBe(29994)
+  })
+  it('rejects anything that is not one', () => {
+    // A NaN reaching a SQL parameter is a 500 waiting to happen.
+    for (const bad of ['', 'abc', '-1', '0', '1.5', '12e3', ' 12 ']) {
+      expect(() => parseIdNorma(bad)).toThrow(BadRequest)
+    }
+  })
+})
+
+describe('parseFecha', () => {
+  it('accepts YYYY-MM-DD and falls back when absent', () => {
+    expect(parseFecha('2020-01-31', '2026-01-01')).toBe('2020-01-31')
+    expect(parseFecha(null, '2026-01-01')).toBe('2026-01-01')
+  })
+  it('rejects a malformed date rather than searching an unintended day', () => {
+    for (const bad of ['ayer', '2020-1-1', '20200101', '2020-13-01']) {
+      expect(() => parseFecha(bad, '2026-01-01')).toThrow(BadRequest)
+    }
+  })
+})

--- a/site/lib/apiparams.ts
+++ b/site/lib/apiparams.ts
@@ -1,0 +1,24 @@
+import { BadRequest } from './apiroute'
+
+/** Strict positive integer. Anything else is a 400, never a NaN handed to a
+ *  SQL parameter. */
+export function parseIdNorma(raw: string): number {
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new BadRequest(`idNorma must be a positive integer, got "${raw}"`)
+  }
+  return Number(raw)
+}
+
+/** YYYY-MM-DD, validated as a real calendar date. A malformed fecha must not
+ *  silently become "today" — the answer would be right-looking and wrong. */
+export function parseFecha(raw: string | null, fallback: string): string {
+  if (raw === null || raw === '') return fallback
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    throw new BadRequest(`fecha must be YYYY-MM-DD, got "${raw}"`)
+  }
+  const d = new Date(`${raw}T00:00:00Z`)
+  if (Number.isNaN(d.getTime()) || d.toISOString().slice(0, 10) !== raw) {
+    throw new BadRequest(`fecha is not a real date: "${raw}"`)
+  }
+  return raw
+}

--- a/site/lib/apiroute.test.ts
+++ b/site/lib/apiroute.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const verifyApiKey = vi.fn()
+const recordUsage = vi.fn()
+vi.mock('./apikey', () => ({ verifyApiKey }))
+vi.mock('./apiusage', () => ({ recordUsage }))
+
+beforeEach(() => {
+  vi.resetModules()
+  verifyApiKey.mockReset()
+  recordUsage.mockReset().mockResolvedValue(undefined)
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+const CTX = { params: Promise.resolve({}) }
+const req = (auth?: string) =>
+  new Request('https://x/v1/search?q=a', auth ? { headers: { authorization: auth } } : undefined)
+
+async function wrap(handler: () => Promise<Response>) {
+  const { withApiKey } = await import('./apiroute')
+  return withApiKey('/v1/search', handler)
+}
+
+describe('withApiKey', () => {
+  it('401s with no Authorization header, and records nothing', async () => {
+    const res = await (await wrap(async () => Response.json({})))(req(), CTX)
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: { code: 'missing_api_key', message: expect.any(String) } })
+    // Unattributable traffic cannot be recorded — there is no key to attribute it to.
+    expect(recordUsage).not.toHaveBeenCalled()
+  })
+
+  it('401s on a non-Bearer scheme', async () => {
+    const res = await (await wrap(async () => Response.json({})))(req('Basic abc'), CTX)
+    expect(res.status).toBe(401)
+  })
+
+  it('401s on an unknown or revoked key', async () => {
+    verifyApiKey.mockResolvedValue(null)
+    const res = await (await wrap(async () => Response.json({})))(req('Bearer lc_live_x'), CTX)
+    expect(res.status).toBe(401)
+    expect((await res.json()).error.code).toBe('invalid_api_key')
+  })
+
+  it('runs the handler for a valid key and records the call', async () => {
+    verifyApiKey.mockResolvedValue({ id: 7, label: 'Acme' })
+    const res = await (await wrap(async () => Response.json({ ok: true })))(req('Bearer lc_live_x'), CTX)
+    expect(res.status).toBe(200)
+    const [keyId, endpoint, status, duration] = recordUsage.mock.calls[0]
+    expect(keyId).toBe(7)
+    expect(endpoint).toBe('/v1/search')
+    expect(status).toBe(200)
+    expect(typeof duration).toBe('number')
+  })
+
+  it('turns a database failure into 503, never a 200 with empty data', async () => {
+    // The 2026-09-07 outage in one assertion: a broken dependency was reported
+    // as an empty successful result, so monitoring saw only healthy 200s.
+    verifyApiKey.mockResolvedValue({ id: 7, label: 'Acme' })
+    const boom = async () => { throw new Error('connection terminated') }
+    const res = await (await wrap(boom))(req('Bearer lc_live_x'), CTX)
+    expect(res.status).toBe(503)
+    expect((await res.json()).error.code).toBe('service_unavailable')
+    expect(recordUsage.mock.calls[0][2]).toBe(503)
+  })
+
+  it('maps NotFound to 404 and BadRequest to 400', async () => {
+    verifyApiKey.mockResolvedValue({ id: 7, label: 'Acme' })
+    const { NotFound, BadRequest } = await import('./apiroute')
+    const nf = await (await wrap(async () => { throw new NotFound('no such norma') }))(req('Bearer k'), CTX)
+    expect(nf.status).toBe(404)
+    expect((await nf.json()).error.code).toBe('not_found')
+    const br = await (await wrap(async () => { throw new BadRequest('bad fecha') }))(req('Bearer k'), CTX)
+    expect(br.status).toBe(400)
+    expect((await br.json()).error.code).toBe('bad_request')
+  })
+
+  it('does not fail the request when usage recording rejects', async () => {
+    verifyApiKey.mockResolvedValue({ id: 7, label: 'Acme' })
+    recordUsage.mockRejectedValue(new Error('db down'))
+    const res = await (await wrap(async () => Response.json({ ok: true })))(req('Bearer k'), CTX)
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('jsonOk', () => {
+  it('marks responses private so no shared cache stores authenticated data', async () => {
+    const { jsonOk } = await import('./apiroute')
+    const cc = jsonOk({ a: 1 }, 300).headers.get('cache-control')
+    expect(cc).toContain('private')
+    expect(cc).not.toContain('public')
+    expect(cc).toContain('max-age=300')
+  })
+})

--- a/site/lib/apiroute.test.ts
+++ b/site/lib/apiroute.test.ts
@@ -42,6 +42,16 @@ describe('withApiKey', () => {
     expect((await res.json()).error.code).toBe('invalid_api_key')
   })
 
+  it('503s when the key lookup itself throws, and records nothing', async () => {
+    // Distinguishes a database failure during auth (503) from an unknown or
+    // revoked key (401, tested above) — these must never collapse together.
+    verifyApiKey.mockRejectedValue(new Error('connection terminated'))
+    const res = await (await wrap(async () => Response.json({})))(req('Bearer lc_live_x'), CTX)
+    expect(res.status).toBe(503)
+    expect((await res.json()).error.code).toBe('service_unavailable')
+    expect(recordUsage).not.toHaveBeenCalled()
+  })
+
   it('runs the handler for a valid key and records the call', async () => {
     verifyApiKey.mockResolvedValue({ id: 7, label: 'Acme' })
     const res = await (await wrap(async () => Response.json({ ok: true })))(req('Bearer lc_live_x'), CTX)

--- a/site/lib/apiroute.test.ts
+++ b/site/lib/apiroute.test.ts
@@ -101,4 +101,36 @@ describe('jsonOk', () => {
     expect(cc).not.toContain('public')
     expect(cc).toContain('max-age=300')
   })
+
+  it('sets an ETag on a cacheable response', async () => {
+    const { jsonOk } = await import('./apiroute')
+    const res = jsonOk({ a: 1 }, 300)
+    expect(res.headers.get('etag')).toMatch(/^"[0-9a-f]{32}"$/)
+  })
+
+  it('sets no ETag on a non-cacheable response', async () => {
+    const { jsonOk } = await import('./apiroute')
+    const res = jsonOk({ a: 1 })
+    expect(res.headers.get('etag')).toBeNull()
+  })
+
+  it('returns 304 with no body when If-None-Match matches the computed ETag', async () => {
+    const { jsonOk } = await import('./apiroute')
+    const first = jsonOk({ a: 1 }, 300)
+    const etag = first.headers.get('etag')
+    const req = new Request('https://x/v1/normas/1', { headers: { 'if-none-match': etag! } })
+    const res = jsonOk({ a: 1 }, 300, req)
+    expect(res.status).toBe(304)
+    expect(res.headers.get('etag')).toBe(etag)
+    expect(res.headers.get('cache-control')).toContain('private')
+    expect(await res.text()).toBe('')
+  })
+
+  it('returns 200 with the body when If-None-Match does not match', async () => {
+    const { jsonOk } = await import('./apiroute')
+    const req = new Request('https://x/v1/normas/1', { headers: { 'if-none-match': '"stale"' } })
+    const res = jsonOk({ a: 1 }, 300, req)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ a: 1 })
+  })
 })

--- a/site/lib/apiroute.ts
+++ b/site/lib/apiroute.ts
@@ -1,0 +1,70 @@
+import { verifyApiKey } from './apikey'
+import { recordUsage } from './apiusage'
+
+export type RouteCtx = { params: Promise<Record<string, string>> }
+export type ApiHandler = (req: Request, ctx: RouteCtx) => Promise<Response>
+
+/** Handler-thrown signals the wrapper maps to status codes, so route handlers
+ *  return data or throw meaning, and never assemble error responses. */
+export class NotFound extends Error {}
+export class BadRequest extends Error {}
+
+export function apiError(status: number, code: string, message: string): Response {
+  return Response.json({ error: { code, message } }, { status })
+}
+
+/** `private`, never `public`: these responses sit behind an Authorization
+ *  header and must not be stored by a shared cache. */
+export function jsonOk(body: unknown, cacheSeconds = 0): Response {
+  const headers: Record<string, string> = { 'content-type': 'application/json' }
+  if (cacheSeconds > 0) headers['cache-control'] = `private, max-age=${cacheSeconds}`
+  return new Response(JSON.stringify(body), { status: 200, headers })
+}
+
+/** Authenticate, time, record, and normalise errors for one endpoint.
+ *
+ *  `endpoint` MUST be the route template ('/v1/normas/{idNorma}'), because it
+ *  is what gets logged — see lib/apiusage.ts.
+ *
+ *  An unrecognised throw becomes 503, not 200-with-nothing. On 2026-09-07 a
+ *  dependency failure was reported as an empty successful result and a total
+ *  outage looked, to monitoring, like a wall of healthy 200s. */
+export function withApiKey(endpoint: string, handler: ApiHandler) {
+  return async (req: Request, ctx: RouteCtx): Promise<Response> => {
+    const started = Date.now()
+    const auth = req.headers.get('authorization') ?? ''
+    const m = /^Bearer\s+(\S+)$/i.exec(auth)
+    if (!m) {
+      return apiError(401, 'missing_api_key',
+        'Provide an API key as: Authorization: Bearer lc_live_…')
+    }
+
+    const key = await verifyApiKey(m[1])
+    if (!key) {
+      return apiError(401, 'invalid_api_key', 'The API key is unknown or has been revoked.')
+    }
+
+    let res: Response
+    try {
+      res = await handler(req, ctx)
+    } catch (err) {
+      if (err instanceof NotFound) {
+        res = apiError(404, 'not_found', err.message)
+      } else if (err instanceof BadRequest) {
+        res = apiError(400, 'bad_request', err.message)
+      } else {
+        console.error(`[api] ${endpoint} failed:`, err)
+        res = apiError(503, 'service_unavailable', 'The service is temporarily unavailable.')
+      }
+    }
+
+    // Dispatched, not awaited: recording must add no latency. The site runs a
+    // single persistent Node replica, so the insert completes after the
+    // response is sent. `.catch` because recordUsage's own guard could still be
+    // bypassed by a rejection at dispatch time.
+    void recordUsage(key.id, endpoint, res.status, Date.now() - started)
+      .catch((e) => console.error('[api] usage dispatch failed:', e))
+
+    return res
+  }
+}

--- a/site/lib/apiroute.ts
+++ b/site/lib/apiroute.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { verifyApiKey } from './apikey'
 import { recordUsage } from './apiusage'
 
@@ -14,11 +15,26 @@ export function apiError(status: number, code: string, message: string): Respons
 }
 
 /** `private`, never `public`: these responses sit behind an Authorization
- *  header and must not be stored by a shared cache. */
-export function jsonOk(body: unknown, cacheSeconds = 0): Response {
+ *  header and must not be stored by a shared cache.
+ *
+ *  An ETag is attached only when `cacheSeconds > 0` — that scopes it to
+ *  exactly the cacheable reads (norma, article, version) the spec names, and
+ *  leaves uncacheable responses like /v1/search without one. When `req`
+ *  carries a matching `If-None-Match`, the body is dropped and a 304 is
+ *  returned instead — still routed through the caller's normal usage
+ *  recording, since this is a Response like any other. */
+export function jsonOk(body: unknown, cacheSeconds = 0, req?: Request): Response {
+  const json = JSON.stringify(body)
   const headers: Record<string, string> = { 'content-type': 'application/json' }
-  if (cacheSeconds > 0) headers['cache-control'] = `private, max-age=${cacheSeconds}`
-  return new Response(JSON.stringify(body), { status: 200, headers })
+  if (cacheSeconds > 0) {
+    headers['cache-control'] = `private, max-age=${cacheSeconds}`
+    const etag = `"${createHash('sha256').update(json).digest('hex').slice(0, 32)}"`
+    headers['etag'] = etag
+    if (req?.headers.get('if-none-match') === etag) {
+      return new Response(null, { status: 304, headers })
+    }
+  }
+  return new Response(json, { status: 200, headers })
 }
 
 /** Authenticate, time, record, and normalise errors for one endpoint.

--- a/site/lib/apiroute.ts
+++ b/site/lib/apiroute.ts
@@ -39,7 +39,13 @@ export function withApiKey(endpoint: string, handler: ApiHandler) {
         'Provide an API key as: Authorization: Bearer lc_live_…')
     }
 
-    const key = await verifyApiKey(m[1])
+    let key
+    try {
+      key = await verifyApiKey(m[1])
+    } catch (err) {
+      console.error(`[api] ${endpoint} auth lookup failed:`, err)
+      return apiError(503, 'service_unavailable', 'The service is temporarily unavailable.')
+    }
     if (!key) {
       return apiError(401, 'invalid_api_key', 'The API key is unknown or has been revoked.')
     }

--- a/site/lib/apiusage.test.ts
+++ b/site/lib/apiusage.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const query = vi.fn()
+vi.mock('./db', () => ({ pool: { query } }))
+
+beforeEach(() => {
+  vi.resetModules()
+  query.mockReset()
+})
+
+describe('recordUsage', () => {
+  it('writes one row with the key, endpoint, status and duration', async () => {
+    query.mockResolvedValue({ rows: [] })
+    const { recordUsage } = await import('./apiusage')
+    await recordUsage(7, '/v1/normas/{idNorma}', 200, 42)
+    expect(query.mock.calls[0][1]).toEqual([7, '/v1/normas/{idNorma}', 200, 42])
+  })
+
+  it('never rejects when the insert fails', async () => {
+    // Usage recording is observability. It must not be able to fail a request
+    // that already produced a correct response.
+    query.mockRejectedValue(new Error('deadlock detected'))
+    const { recordUsage } = await import('./apiusage')
+    await expect(recordUsage(7, '/v1/search', 200, 5)).resolves.toBeUndefined()
+  })
+
+  it('refuses a concrete path, which would defeat the privacy guarantee', async () => {
+    // The template is the whole point: '/v1/normas/29994' is a record of which
+    // law someone read. Catching this in a unit test is cheaper than catching
+    // it in a privacy review after six months of logs.
+    query.mockResolvedValue({ rows: [] })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { recordUsage } = await import('./apiusage')
+    await recordUsage(7, '/v1/normas/29994', 200, 5)
+    expect(query).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('accepts every template the API actually uses', async () => {
+    query.mockResolvedValue({ rows: [] })
+    const { recordUsage } = await import('./apiusage')
+    for (const t of [
+      '/v1/search',
+      '/v1/normas/{idNorma}',
+      '/v1/normas/{idNorma}/articulos',
+      '/v1/normas/{idNorma}/articulos/{slug}',
+      '/v1/normas/{idNorma}/versiones',
+      '/v1/normas/{idNorma}/diff',
+      '/v1/normas/{idNorma}/modificaciones',
+      '/v1/normas/{idNorma}/raw',
+    ]) {
+      await recordUsage(7, t, 200, 1)
+    }
+    expect(query).toHaveBeenCalledTimes(8)
+  })
+})

--- a/site/lib/apiusage.test.ts
+++ b/site/lib/apiusage.test.ts
@@ -37,6 +37,19 @@ describe('recordUsage', () => {
     errorSpy.mockRestore()
   })
 
+  it('refuses a partially concretized path that would leak article identity', async () => {
+    // A path like '/v1/normas/{idNorma}/articulos/preambulo' with a concrete
+    // article slug reveals which article a caller read — the same privacy leak
+    // the guard exists to prevent, only narrower. The allow-list catches this.
+    query.mockResolvedValue({ rows: [] })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { recordUsage } = await import('./apiusage')
+    await recordUsage(7, '/v1/normas/{idNorma}/articulos/preambulo', 200, 5)
+    expect(query).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
   it('accepts every template the API actually uses', async () => {
     query.mockResolvedValue({ rows: [] })
     const { recordUsage } = await import('./apiusage')

--- a/site/lib/apiusage.ts
+++ b/site/lib/apiusage.ts
@@ -1,0 +1,36 @@
+import { pool } from './db'
+
+/** Endpoint strings must be route templates, not concrete paths.
+ *
+ *  A digit where `{idNorma}` belongs means a caller passed the real path, which
+ *  would turn this table into a record of which laws each key holder read. That
+ *  is the exact data this design chose not to collect, so it is refused rather
+ *  than written. */
+const TEMPLATE_RE = /^\/v1\/[a-zA-Z{}/]*$/
+
+/** Record one API call. Never throws.
+ *
+ *  Callers dispatch this without awaiting, so a rejection would surface as an
+ *  unhandled promise rejection and, on some runtimes, take the process down —
+ *  over a metric. Observability must never be able to fail a request that
+ *  already produced a correct response. */
+export async function recordUsage(
+  keyId: number, endpoint: string, status: number, durationMs: number,
+): Promise<void> {
+  if (!TEMPLATE_RE.test(endpoint)) {
+    console.error(
+      `[api] refusing to record a concrete path as usage: ${endpoint} — ` +
+      `endpoint must be a route template such as /v1/normas/{idNorma}`,
+    )
+    return
+  }
+  try {
+    await pool.query(
+      `INSERT INTO api_usage (key_id, endpoint, status, duration_ms)
+       VALUES ($1, $2, $3, $4)`,
+      [keyId, endpoint, status, durationMs],
+    )
+  } catch (err) {
+    console.error('[api] usage insert failed:', err)
+  }
+}

--- a/site/lib/apiusage.ts
+++ b/site/lib/apiusage.ts
@@ -29,8 +29,7 @@ export async function recordUsage(
 ): Promise<void> {
   if (!KNOWN_ENDPOINTS.has(endpoint)) {
     console.error(
-      `[api] refusing to record unknown endpoint as usage: ${endpoint} — ` +
-      `endpoint must be one of the known route templates`,
+      `[api] refusing to record usage: endpoint is not a known route template (key ${keyId})`,
     )
     return
   }

--- a/site/lib/apiusage.ts
+++ b/site/lib/apiusage.ts
@@ -1,12 +1,22 @@
 import { pool } from './db'
 
-/** Endpoint strings must be route templates, not concrete paths.
+/** Known route templates that are safe to record in usage logs.
  *
- *  A digit where `{idNorma}` belongs means a caller passed the real path, which
- *  would turn this table into a record of which laws each key holder read. That
- *  is the exact data this design chose not to collect, so it is refused rather
- *  than written. */
-const TEMPLATE_RE = /^\/v1\/[a-zA-Z{}/]*$/
+ *  The usage log must never identify what a caller read. All endpoints must be
+ *  route templates (with variable segments like {idNorma}), never concrete paths.
+ *  An explicit allow-list enforces this directly. Adding a new endpoint requires
+ *  adding its template here — deliberate friction appropriate for a privacy guarantee.
+ */
+export const KNOWN_ENDPOINTS = new Set([
+  '/v1/search',
+  '/v1/normas/{idNorma}',
+  '/v1/normas/{idNorma}/articulos',
+  '/v1/normas/{idNorma}/articulos/{slug}',
+  '/v1/normas/{idNorma}/versiones',
+  '/v1/normas/{idNorma}/diff',
+  '/v1/normas/{idNorma}/modificaciones',
+  '/v1/normas/{idNorma}/raw',
+])
 
 /** Record one API call. Never throws.
  *
@@ -17,10 +27,10 @@ const TEMPLATE_RE = /^\/v1\/[a-zA-Z{}/]*$/
 export async function recordUsage(
   keyId: number, endpoint: string, status: number, durationMs: number,
 ): Promise<void> {
-  if (!TEMPLATE_RE.test(endpoint)) {
+  if (!KNOWN_ENDPOINTS.has(endpoint)) {
     console.error(
-      `[api] refusing to record a concrete path as usage: ${endpoint} — ` +
-      `endpoint must be a route template such as /v1/normas/{idNorma}`,
+      `[api] refusing to record unknown endpoint as usage: ${endpoint} — ` +
+      `endpoint must be one of the known route templates`,
     )
     return
   }

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
+
+export default defineConfig({
+  resolve: {
+    alias: { '@': fileURLToPath(new URL('.', import.meta.url)) },
+  },
+})

--- a/sql/006_api.sql
+++ b/sql/006_api.sql
@@ -1,0 +1,76 @@
+-- Public REST API: keys and usage.
+--
+-- Keys are stored as SHA-256 digests. The plaintext is returned once by
+-- issue_api_key and is unrecoverable afterwards, so a database leak yields no
+-- usable credentials.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS api_key (
+  id         bigserial PRIMARY KEY,
+  key_hash   text NOT NULL UNIQUE,
+  -- Display only, so a human can tell keys apart in a listing. Never
+  -- sufficient to authenticate with.
+  key_prefix text NOT NULL,
+  label      text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  revoked_at timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS api_usage (
+  id          bigserial PRIMARY KEY,
+  key_id      bigint NOT NULL REFERENCES api_key (id) ON DELETE CASCADE,
+  ts          timestamptz NOT NULL DEFAULT now(),
+  -- The route TEMPLATE ('/v1/normas/{idNorma}'), never the concrete path.
+  -- Storing '/v1/normas/29994' would build a per-caller record of which laws
+  -- someone read — the same category of data as the query text this design
+  -- deliberately does not keep.
+  endpoint    text NOT NULL,
+  status      int NOT NULL,
+  duration_ms int NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS api_usage_key_ts_idx ON api_usage (key_id, ts DESC);
+CREATE INDEX IF NOT EXISTS api_usage_ts_idx     ON api_usage (ts);
+
+-- Returns the plaintext key ONCE. There is no way to recover it later.
+CREATE OR REPLACE FUNCTION issue_api_key(p_label text)
+RETURNS text LANGUAGE plpgsql AS $$
+DECLARE
+  raw   text;
+  token text;
+BEGIN
+  IF p_label IS NULL OR btrim(p_label) = '' THEN
+    RAISE EXCEPTION 'label is required';
+  END IF;
+  -- 24 bytes of CSPRNG, base64url. translate() strips the base64 characters
+  -- that are unsafe in a URL or an Authorization header.
+  raw   := translate(encode(gen_random_bytes(24), 'base64'), '+/=', '-_');
+  token := 'lc_live_' || raw;
+  INSERT INTO api_key (key_hash, key_prefix, label)
+  VALUES (encode(digest(token, 'sha256'), 'hex'), left(token, 16), btrim(p_label));
+  RETURN token;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION revoke_api_key(p_prefix text)
+RETURNS boolean LANGUAGE plpgsql AS $$
+DECLARE n int;
+BEGIN
+  UPDATE api_key SET revoked_at = now()
+   WHERE key_prefix = p_prefix AND revoked_at IS NULL;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RETURN n > 0;
+END
+$$;
+
+-- Mirrors the 90-day prune retier.py already applies to analytics.event.
+CREATE OR REPLACE FUNCTION prune_api_usage(p_days int DEFAULT 90)
+RETURNS bigint LANGUAGE plpgsql AS $$
+DECLARE n bigint;
+BEGIN
+  DELETE FROM api_usage WHERE ts < now() - make_interval(days => p_days);
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RETURN n;
+END
+$$;


### PR DESCRIPTION
A read-only JSON API over the corpus at `/v1`, covering the same ground as the MCP server, authenticated with hand-provisioned API keys, with per-key usage recorded for observability.

**Not merged into anything yet — `/v1` will 503 on every call until `sql/006_api.sql` is applied to production.** That step is deliberately not in this PR.

## Why not a wrapper around MCP

`/api/mcp` returns prose shaped for a model's context window. A REST client wants JSON, and wrapping one in the other would force every consumer to parse text formatted for an LLM. Both are now presentation layers over the same `@/lib/norma` and `@/lib/search` functions, so the article cap, the `idNorma` ambiguity handling and the as-of semantics stay in one place.

## Endpoints

| endpoint | MCP equivalent |
|---|---|
| `GET /v1/search?q=&asOf=&limit=` | `search_laws` |
| `GET /v1/search?tipo=&numero=` | citation lookup |
| `GET /v1/normas/{idNorma}` | `get_law` |
| `GET /v1/normas/{idNorma}/articulos?q=&fecha=` | `search_articles` |
| `GET /v1/normas/{idNorma}/articulos/{slug}` | `get_article` |
| `GET /v1/normas/{idNorma}/versiones` | `list_versions` |
| `GET /v1/normas/{idNorma}/diff?from=&to=` | `diff_versions` |
| `GET /v1/normas/{idNorma}/modificaciones` | `get_modifications` |
| `GET /v1/normas/{idNorma}/raw?fecha=` | `get_raw_link` |

`idNorma` addresses everything, because `(tipo, numero)` is not unique — many `DFL 1` exist, one per organismo, and `/ley/20780` once resolved to a decreto whose `id_norma` happened to be 20780. A citation returns **every** candidate so callers disambiguate deliberately.

## Auth and keys

`Authorization: Bearer lc_live_…`. Only the SHA-256 digest is stored; `issue_api_key('label')` returns the plaintext once and it is unrecoverable after that. Revoke with `revoke_api_key('lc_live_prefix')`. Verification is one indexed probe, and revocation is filtered in SQL rather than returned for a caller to check.

## Usage tracking — and the privacy line

`api_usage` stores the **route template**, never the concrete path. `/v1/normas/29994` would be a record of which law someone read; `/v1/normas/{idNorma}` is not. Recorded: key, endpoint template, status, duration, timestamp. Not recorded: query text, path parameters, IP, user-agent. Pruned at 90 days, mirroring `analytics.event`.

`recordUsage` refuses anything outside an allow-list of the eight templates, and a test enumerates the same eight — so a route added without registering its template fails a test rather than silently logging nothing.

**This is an explicit change in posture.** `sql/001_schema.sql` records that `analytics.event` collects no user dimension; this introduces one for API consumers. It is scoped as narrowly as the requirement allows and documented in the spec.

## Review found five real defects

Every one was in code from the implementation plan, caught by per-task or whole-branch review:

1. The usage guard rejected concrete paths by detecting digits, so `/v1/normas/{idNorma}/articulos/preambulo` passed — leaking which *article* was read. Replaced with the explicit allow-list.
2. A Postgres failure during **authentication** threw past the error envelope, bypassing the 503 mapping — structurally the same failure as the 2026-09-07 outage. Now 503, with a test pinning that a thrown error and a `null` return stay distinct.
3. The citation branch applied `.slice(0, limit)`, silently dropping candidates — the exact failure `idNorma` addressing exists to prevent.
4. `/v1/search` validated `asOf` with a local regex, accepting `2026-02-31` where every other endpoint 400s. Now routed through the shared `parseFecha`.
5. The spec promised an `ETag` the API never sent. Implemented in `jsonOk` with `If-None-Match` → 304.

## Verification

142 tests passing, 1 skipped; `tsc --noEmit` clean. Fourteen commits, each independently reviewed.

## Deploy order

`sql/006_api.sql` must be applied **before** this ships. Then `SELECT issue_api_key('…')` to mint the first key.

## Not in scope

Rate limiting and quotas (the usage table makes both easy later), key self-service, writes, OpenAPI generation, and CORS — with auth in an `Authorization` header no browser can call `/v1` cross-origin, which is fine for server consumers but worth deciding before clients exist.

Spec: `docs/superpowers/specs/2026-09-08-public-api-design.md`
Plan: `docs/superpowers/plans/2026-09-08-public-api.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5a463XjtoDsYpMC7Vzhi6