### PR TITLE
docs(api): consumer documentation, and correct the API's URL to /api/v1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,34 @@ site/ (Next.js 16)     → SSR pages + tiered search, on Railway
 
 **MCP server.** `site/app/api/[transport]/route.ts` is a stateless Streamable HTTP MCP server (`mcp-handler`) at **`https://leyes.pisanvs.cl/api/mcp`**, read-only, no auth. Tools: `search_laws`, `get_law`, `get_article`, `list_versions`, `diff_versions`, `get_modifications`, `search_articles`; output is deliberately capped (one norma can be ~350KB). The `[transport]` segment lives under `/api` because `app/[transport]` would collide with `app/[tipo]/[numero]` — static `/api/*` siblings still win over the dynamic segment.
 
+**Public REST API.** `site/app/api/v1/**` is a read-only JSON API at
+**`https://leyes.pisanvs.cl/api/v1`**, authenticated with `Authorization: Bearer
+lc_live_…`. Same data layer as the MCP server (`@/lib/norma`, `@/lib/search`) —
+JSON rather than prose. Eight endpoints covering the MCP tool set: `search`,
+`normas/{idNorma}`, `.../articulos`, `.../articulos/{slug}`, `.../versiones`,
+`.../diff`, `.../modificaciones`, `.../raw`.
+
+Keys: `SELECT issue_api_key('label')` returns the plaintext **once** (only the
+SHA-256 is stored, so it is unrecoverable after that); `SELECT
+revoke_api_key('lc_live_prefix')` revokes, effective on the next request.
+
+Usage is recorded per key in `api_usage`, storing the **route template** and
+never the concrete path — `/v1/normas/{idNorma}`, not `/v1/normas/29994` — so
+the log cannot become a record of which laws a caller read. `recordUsage`
+refuses any endpoint outside `KNOWN_ENDPOINTS` in `site/lib/apiusage.ts`, so
+**a new route must add its template there or its usage is silently never
+recorded** (a test enumerates all eight). Pruned at 90 days by
+`prune_api_usage()`.
+
+Note the recorded template omits the `/api` prefix the routes are actually
+served under: the handlers live beneath `site/app/api/`, so Next mounts them at
+`/api/v1/…`, while the usage label stays `/v1/…` as a stable identifier that
+should not churn if the mount point moves.
+
+Schema: `sql/006_api.sql` (needs `pgcrypto`) — **must be applied before the code
+deploys**, or every `/api/v1` call 503s. Docs: `docs/api.md`. Spec:
+`docs/superpowers/specs/2026-09-08-public-api-design.md`.
+
 **Local dev / running the loader:**
 
 ```bash

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,259 @@
+# LeyChile API
+
+A read-only JSON API over the Chilean legal corpus — 333,026 normas, every
+historical version of each, and the modification graph between them.
+
+**Base URL:** `https://leyes.pisanvs.cl/api/v1`
+
+There is also an [MCP server](https://leyes.pisanvs.cl/api/mcp) over the same
+data, for language models. It returns prose; this API returns JSON.
+
+## Authentication
+
+Every endpoint requires a key:
+
+```
+Authorization: Bearer lc_live_…
+```
+
+Keys are issued by hand — ask the operator. A missing, unknown or revoked key
+returns `401`.
+
+```bash
+curl -H "Authorization: Bearer $LEYCHILE_KEY" \
+  'https://leyes.pisanvs.cl/api/v1/search?q=medio+ambiente'
+```
+
+## `idNorma` is the identifier that works
+
+**`(tipo, numero)` does not identify a Chilean norma.** There are 227 `DFL 1`,
+75 `DFL 4` and 525 `DTO 1`, from different organismos and years. Worse, an
+internal `idNorma` can coincide with an unrelated law's `numero` — `/ley/20780`
+once resolved to a decreto whose `idNorma` happened to be 20780.
+
+So every endpoint addresses normas by `idNorma`, and a citation lookup returns
+**every** candidate rather than guessing:
+
+```bash
+curl -H "Authorization: Bearer $KEY" \
+  'https://leyes.pisanvs.cl/api/v1/search?tipo=dfl&numero=1'
+```
+
+Pick the one you meant from `idNorma` + `organismo`, then use `idNorma` for
+everything after.
+
+## Endpoints
+
+### `GET /search`
+
+Free text (`q`, 2+ characters) or citation (`tipo` + `numero`).
+
+| parameter | |
+|---|---|
+| `q` | search terms, minimum 2 characters |
+| `tipo` + `numero` | citation lookup; returns all candidates |
+| `asOf` | `YYYY-MM-DD`, defaults to today — searches the text in force on that date |
+| `limit` | 1–100, default 20 (free-text only; a citation always returns every candidate) |
+
+```bash
+curl -H "Authorization: Bearer $KEY" \
+  'https://leyes.pisanvs.cl/api/v1/search?q=partidos+politicos&limit=2'
+```
+
+```json
+{
+  "query": "partidos politicos",
+  "asOf": "2026-09-09",
+  "total": 2,
+  "resultados": [
+    {
+      "idNorma": 29994,
+      "tipo": "ley",
+      "numero": "18603",
+      "titulo": "LEY ORGANICA CONSTITUCIONAL DE LOS PARTIDOS POLITICOS",
+      "organismo": "MINISTERIO DEL INTERIOR"
+    }
+  ]
+}
+```
+
+### `GET /normas/{idNorma}`
+
+Metadata plus an article **index**. Never article bodies — a single norma can
+be ~350 KB, so bodies are fetched one at a time.
+
+```json
+{
+  "idNorma": 29994,
+  "tipo": "ley",
+  "numero": "18603",
+  "titulo": "LEY ORGANICA CONSTITUCIONAL DE LOS PARTIDOS POLITICOS",
+  "organismo": "MINISTERIO DEL INTERIOR",
+  "derogado": false,
+  "fechaPublicacion": "1987-03-23",
+  "fecha": "2016-04-15",
+  "totalVersiones": 6,
+  "articulos": [
+    { "slug": "art-1", "label": "articulo 1", "rawHeading": "Artículo 1º" }
+  ]
+}
+```
+
+`fecha` is the version described. Pass `?fecha=YYYY-MM-DD` for a historical one.
+
+### `GET /normas/{idNorma}/articulos`
+
+The article index at a date. With `q` (2+ chars) it searches **inside** the
+norma and returns only matching articles, each with a `snippet` marked up with
+`<b>` around the hit — the way to find the relevant article of a code with
+hundreds of them without downloading its text.
+
+```bash
+curl -H "Authorization: Bearer $KEY" \
+  'https://leyes.pisanvs.cl/api/v1/normas/29994/articulos?q=militante'
+```
+
+### `GET /normas/{idNorma}/articulos/{slug}`
+
+One article body.
+
+```json
+{
+  "idNorma": 29994, "fecha": "2016-04-15",
+  "slug": "art-1", "label": "articulo 1", "rawHeading": "Artículo 1º",
+  "body": "Los partidos políticos son asociaciones autónomas y voluntarias…",
+  "truncado": false,
+  "largoCompleto": 970
+}
+```
+
+Bodies are capped at 12,000 characters. When `truncado` is `true` the text is
+incomplete and `largoCompleto` gives the real length — never treat a truncated
+article as the whole provision.
+
+### `GET /normas/{idNorma}/versiones`
+
+Every version, with the window each was in force.
+
+```json
+{
+  "idNorma": 29994, "vigente": "2016-04-15", "total": 6,
+  "versiones": [
+    { "desde": "1987-03-23", "hasta": "2011-10-16", "causaId": null, "subject": "…" }
+  ]
+}
+```
+
+`desde` values are the dates to pass as `fecha`, `from` and `to` elsewhere.
+
+### `GET /normas/{idNorma}/diff?from=&to=`
+
+What changed between two versions — the question this corpus exists to answer.
+Both dates are required.
+
+```json
+{
+  "idNorma": 29994, "from": "2015-05-05", "to": "2016-04-15",
+  "resumen": { "modificados": 53, "añadidos": 16, "eliminados": 0 },
+  "cambios": [
+    {
+      "slug": "art-1",
+      "rawHeading": "Artículo 1º",
+      "estado": "modificado",
+      "ops": [
+        { "op": "delete", "text": "voluntarias, dotadas de personalidad jurídica…" },
+        { "op": "insert", "text": "autónomas y voluntarias organizadas democráticamente…" }
+      ]
+    }
+  ]
+}
+```
+
+`estado` is `modificado`, `añadido` or `eliminado`. A norma that did not change
+returns `200` with an empty `cambios` array — that is an answer, not an error.
+
+### `GET /normas/{idNorma}/modificaciones`
+
+Both directions of the modification graph. Every entry carries `idNorma`, so
+you never have to resolve an ambiguous citation.
+
+```json
+{
+  "idNorma": 29994,
+  "modifica": [],
+  "modificadaPor": [
+    { "idNorma": 1089164, "tipo": "ley", "numero": "20915",
+      "titulo": "FORTALECE EL CARÁCTER PÚBLICO Y DEMOCRÁTICO…", "fecha": "2016-04-15" }
+  ]
+}
+```
+
+### `GET /normas/{idNorma}/raw?fecha=`
+
+Canonical links to the authoritative source at leychile.cl, for citing or
+verifying.
+
+## Errors
+
+```json
+{ "error": { "code": "invalid_api_key", "message": "…" } }
+```
+
+| status | meaning |
+|---|---|
+| `400` | malformed `idNorma` or date, or a missing required parameter |
+| `401` | missing, malformed, unknown or revoked key |
+| `404` | no such norma, article or version |
+| `503` | the service is temporarily unavailable |
+
+An empty `resultados` or `cambios` array means **nothing matched**. It never
+means the service is broken — that is always a `4xx` or `5xx`.
+
+Dates must be real calendar dates: `2026-02-31` is a `400`, not a silent
+substitution.
+
+## Caching
+
+Norma, article and version reads carry an `ETag` and
+`Cache-Control: private, max-age=300`. Send the ETag back as `If-None-Match` to
+get a `304` and skip the payload:
+
+```bash
+curl -H "Authorization: Bearer $KEY" -H 'If-None-Match: "82b8be35…"' \
+  'https://leyes.pisanvs.cl/api/v1/normas/29994'
+```
+
+`private` is deliberate: responses sit behind an `Authorization` header and must
+not be stored by a shared cache. Search results are not cached.
+
+## What is logged
+
+Per request: **the API key, the route template, the HTTP status, the duration,
+and the timestamp.**
+
+**Not logged:** your search terms, which norma or article you requested, your IP
+address, or your user agent.
+
+The route template is stored — `/v1/normas/{idNorma}` — never the concrete path.
+That is deliberate: recording `/v1/normas/29994` would build a record of which
+laws a given key holder reads, and this API does not keep that. Usage rows are
+deleted after **90 days**.
+
+The corpus itself is public and collects no user dimension; the API key exists
+so the operator can see call volume and revoke abuse, not to track reading.
+
+## Limits
+
+No rate limit or quota is enforced today. That may change as traffic grows, and
+would be announced before it does. Be reasonable: the corpus is 333k normas
+served by one small instance.
+
+## Notes
+
+- Field names use Spanish domain terms (`titulo`, `numero`, `articulos`,
+  `versiones`). `norma`, `dfl` and `dto` have no honest English equivalents.
+- Every endpoint is `GET` and read-only.
+- No CORS headers are sent, so browsers cannot call this cross-origin. It is
+  built for server-to-server use.
+- The data is derived from leychile.cl and rebuilt from a git history of the
+  corpus; `/raw` links back to the authoritative source.

--- a/docs/superpowers/specs/2026-09-08-public-api-design.md
+++ b/docs/superpowers/specs/2026-09-08-public-api-design.md
@@ -27,7 +27,7 @@ presentation layer over those same functions.
                         │              │
         ┌───────────────┴──────┬───────┴────────────┐
         │                      │                    │
-   MCP  (prose)          REST /v1 (JSON)        site pages
+   MCP  (prose)          REST /api/v1 (JSON)        site pages
 ```
 
 Behaviour that must not diverge — the 12 KB article-body cap, the `idNorma`
@@ -36,19 +36,19 @@ surfaces inherit it rather than reimplementing it.
 
 ## Endpoints
 
-All under `/v1`, all `GET`, all requiring a key.
+All under `/api/v1`, all `GET`, all requiring a key.
 
 | endpoint | returns |
 |---|---|
-| `/v1/search?q=&asOf=&limit=` | normas matching free text |
-| `/v1/search?tipo=&numero=` | normas matching a citation, all candidates |
-| `/v1/normas/{idNorma}` | metadata + article index, no bodies |
-| `/v1/normas/{idNorma}/articulos?fecha=&q=` | article index at a fecha; `q` searches **within** the norma and adds snippets |
-| `/v1/normas/{idNorma}/articulos/{slug}?fecha=` | one article body |
-| `/v1/normas/{idNorma}/versiones` | version history |
-| `/v1/normas/{idNorma}/diff?from=&to=` | structured diff between two versions |
-| `/v1/normas/{idNorma}/modificaciones` | what modified this norma, and what it modified |
-| `/v1/normas/{idNorma}/raw?fecha=` | canonical upstream leychile.cl link |
+| `/api/v1/search?q=&asOf=&limit=` | normas matching free text |
+| `/api/v1/search?tipo=&numero=` | normas matching a citation, all candidates |
+| `/api/v1/normas/{idNorma}` | metadata + article index, no bodies |
+| `/api/v1/normas/{idNorma}/articulos?fecha=&q=` | article index at a fecha; `q` searches **within** the norma and adds snippets |
+| `/api/v1/normas/{idNorma}/articulos/{slug}?fecha=` | one article body |
+| `/api/v1/normas/{idNorma}/versiones` | version history |
+| `/api/v1/normas/{idNorma}/diff?from=&to=` | structured diff between two versions |
+| `/api/v1/normas/{idNorma}/modificaciones` | what modified this norma, and what it modified |
+| `/api/v1/normas/{idNorma}/raw?fecha=` | canonical upstream leychile.cl link |
 
 ### Why `idNorma` is the addressing primitive
 
@@ -57,7 +57,7 @@ organismo, and the reader code already carries a hard-won comment: `/ley/20780`
 once resolved to a decreto whose `id_norma` happened to be 20780. Putting an
 ambiguous key in a public URL path would bake that bug into the contract.
 
-Citation-style access is served by `/v1/search?tipo=ley&numero=20780`, which
+Citation-style access is served by `/api/v1/search?tipo=ley&numero=20780`, which
 returns every candidate with its `idNorma` and `organismo` so the caller can
 disambiguate deliberately rather than accidentally.
 
@@ -65,14 +65,14 @@ disambiguate deliberately rather than accidentally.
 
 | MCP tool | REST equivalent |
 |---|---|
-| `search_laws` | `GET /v1/search` |
-| `search_articles` | `GET /v1/normas/{idNorma}/articulos?q=` |
-| `get_law` | `GET /v1/normas/{idNorma}` |
-| `get_article` | `GET /v1/normas/{idNorma}/articulos/{slug}` |
-| `list_versions` | `GET /v1/normas/{idNorma}/versiones` |
-| `diff_versions` | `GET /v1/normas/{idNorma}/diff` |
-| `get_modifications` | `GET /v1/normas/{idNorma}/modificaciones` |
-| `get_raw_link` | `GET /v1/normas/{idNorma}/raw` |
+| `search_laws` | `GET /api/v1/search` |
+| `search_articles` | `GET /api/v1/normas/{idNorma}/articulos?q=` |
+| `get_law` | `GET /api/v1/normas/{idNorma}` |
+| `get_article` | `GET /api/v1/normas/{idNorma}/articulos/{slug}` |
+| `list_versions` | `GET /api/v1/normas/{idNorma}/versiones` |
+| `diff_versions` | `GET /api/v1/normas/{idNorma}/diff` |
+| `get_modifications` | `GET /api/v1/normas/{idNorma}/modificaciones` |
+| `get_raw_link` | `GET /api/v1/normas/{idNorma}/raw` |
 
 `search_articles` becomes a query parameter rather than its own path because it
 is a filter over the same collection the bare endpoint returns — with `q` the
@@ -143,6 +143,12 @@ CREATE INDEX api_usage_ts_idx     ON api_usage (ts);
 
 **`endpoint` stores the route template, never the concrete path** —
 `/v1/normas/{idNorma}/articulos/{slug}`, not `/v1/normas/29994/articulos/a3`.
+
+Note the template is a stable **identifier**, not the URL. The served path is
+`/api/v1/…` (the handlers live under `site/app/api/`, so Next mounts them
+there); the recorded label omits the `/api` prefix. They are deliberately
+decoupled: the label is what groups a year of usage rows, and it should not
+churn if the mount point ever moves.
 
 This is the load-bearing privacy decision, not an implementation detail.
 Recording concrete paths would build a per-person record of which laws someone


### PR DESCRIPTION
Docs-only. No code or schema changes.

## The URL was wrong

The API serves at **`/api/v1`**, not `/v1` as the spec, PR #21 and its commit messages all claimed. The handlers live under `site/app/api/`, so Next mounts them there.

That's also where they belong: `CLAUDE.md` already records that the MCP server sits at `/api/mcp` rather than a top-level route because a top-level dynamic segment collides with `app/[tipo]/[numero]`. The spec said `/v1` while the plan placed files under `app/api/v1/`, and nothing reconciled the two until the routes were live and returning HTML 404s at the documented path.

Correcting the documentation rather than moving the routes — nothing external depends on `/v1`, and `/api/v1` is the safer mount point.

## The usage template stays `/v1/…` on purpose

`api_usage.endpoint` records `/v1/normas/{idNorma}`, without the `/api` prefix. That's a stable identifier for grouping usage rows, not a URL, and it shouldn't churn if the mount point ever moves. Both the spec and `CLAUDE.md` now say so explicitly, since otherwise the mismatch reads as a bug.

## `docs/api.md`

Written for consumers, not maintainers. Leads with why `idNorma` rather than `(tipo, numero)` — 227 `DFL 1` exist, and `/ley/20780` once resolved to a decreto whose `idNorma` was 20780 — then a worked `curl` and real response for each of the eight endpoints.

It states plainly what is logged (key, route template, status, duration, timestamp) and what is not (search terms, which norma was read, IP, user agent), with the 90-day retention. `sql/001_schema.sql` records that the corpus collects no user dimension; an authenticated API introduces one, and key holders should be able to read that rather than infer it.

Also documents that no CORS headers are sent, so this is server-to-server only.

## Verified live before writing

22/22 smoke tests against production, and parity checked against the MCP server on identical inputs: same `idNorma`, organismo, publication date, vigente date, 6 versions, 84 articles, same 5 modifications with matching `idNorma`s. Revocation confirmed effective (200 → 401). 49 usage rows recorded, none containing anything but the eight templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5a463XjtoDsYpMC7Vzhi6