### PR TITLE
seo: add Legislation JSON-LD to the canonical norma reader pages

### DIFF
--- a/site/app/norma/[id]/[[...rest]]/page.tsx
+++ b/site/app/norma/[id]/[[...rest]]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next'
 import { notFound, permanentRedirect } from 'next/navigation'
-import { cleanTitulo, SITE } from '@/lib/jsonld'
+import { cleanTitulo, jsonLdScript, legislationJsonLd, SITE } from '@/lib/jsonld'
 import {
-  canonicalPath, getAvisos, getCanonicalNorma, getKeySiblings, getNormaById,
-  getRefundido, getVersions,
+  canonicalPath, currentFecha, getAvisos, getCanonicalNorma, getKeySiblings, getModifiedBy,
+  getNormaById, getRefundido, getVersions,
 } from '@/lib/norma'
 import { canonicalHref } from '@/lib/href'
 import { normaSlug } from '@/lib/slug'
@@ -97,25 +97,40 @@ export default async function Page({ params }: Props) {
   // which is what lets the slug be regenerated freely as data improves.
   if (slug !== normaSlug(norma)) permanentRedirect(canonicalHref(norma, fecha))
 
-  const [canon, avisos, refundido] = await Promise.all([
+  const [canon, avisos, refundido, versions, modifiedBy] = await Promise.all([
     getCanonicalNorma(norma.tipo, norma.numero),
     getAvisos(norma.idNorma),
     getRefundido(norma.idNorma),
+    getVersions(norma.idNorma),
+    getModifiedBy(norma.idNorma),
   ])
   const total = canon?.total ?? 1
   // Still worth surfacing key-siblings inline: a reader who landed here from a
   // citation may well have wanted a different DFL 4.
   const siblings = total > 1 ? await getKeySiblings(norma.tipo, norma.numero, norma.idNorma) : []
   return (
-    <LawView
-      tipo={norma.tipo}
-      numero={norma.numero}
-      idNorma={norma.idNorma}
-      fecha={fecha}
-      siblings={siblings}
-      siblingTotal={total}
-      versionBase={canonicalHref(norma)}
-      banner={<AvisoBanner avisos={avisos} refundido={refundido} />}
-    />
+    <>
+      {/* THE canonical page type for the corpus (~333k pages) — the one
+          structured-data gap the /guia and /cambios siblings don't have. */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: jsonLdScript(legislationJsonLd(
+            norma, fecha ?? currentFecha(versions), versions,
+            modifiedBy.map((m) => Number(m.numero)).filter(Number.isFinite),
+          )),
+        }}
+      />
+      <LawView
+        tipo={norma.tipo}
+        numero={norma.numero}
+        idNorma={norma.idNorma}
+        fecha={fecha}
+        siblings={siblings}
+        siblingTotal={total}
+        versionBase={canonicalHref(norma)}
+        banner={<AvisoBanner avisos={avisos} refundido={refundido} />}
+      />
+    </>
   )
 }


### PR DESCRIPTION
## Problem

The canonical `/norma/{idNorma}/{slug}` route — the primary page type for the entire corpus (~333k pages) — carried **no structured data at all**. Its two derivative page types, `/guia` and `/cambios`, both already emit `legislationJsonLd` (plus `faqJsonLd`/`breadcrumbJsonLd`) via `lib/jsonld.ts`; the reader route just never called it.

Confirmed live:
```
$ curl -s https://leyes.pisanvs.cl/norma/1973/cod-1855-codigo-civil | grep -c 'ld+json'
0
$ curl -s https://leyes.pisanvs.cl/guia/1973/cod-1855-codigo-civil | grep -c 'ld+json'
6
```

## Fix

Fetch `versions` + `modifiedBy` alongside the existing `avisos`/`refundido`/`canon` lookups (same pattern `app/cambios/[...rest]/page.tsx` already uses for its own `legislationJsonLd` call, including converting `modifiedBy`'s `numero` to the numeric `legislationIdentifier` array), and render one `<script type="application/ld+json">` block — matching the JSON-LD wiring already used elsewhere.

**Honesty check on impact**: schema.org's `Legislation` type is not among Google's documented [Rich Results types](https://developers.google.com/search/docs/appearance/structured-data/search-gallery), so this isn't expected to earn a SERP rich snippet. It closes a real inconsistency with the sibling routes and gives structured facts to entity/AI crawlers, at minimal risk — purely additive, and the two extra queries are already used on this exact code path elsewhere in the app.

## Verification

Run from `site/`, with no `DATABASE_URL` set (matches how the Railway image actually builds):

```
$ pnpm build
✓ Compiled successfully
✓ Finished TypeScript
✓ Generating static pages using 3 workers (51/51)

$ npx tsc --noEmit
(clean, no output)

$ pnpm vitest run
 Test Files  21 passed | 1 skipped (22)
      Tests  142 passed | 1 skipped (143)
```
(ran after removing stray `.next/standalone/**/*.test.ts` copies left by a prior `pnpm build` — vitest's default include picks those up too and they fail on missing dev-build modules; unrelated to this change.)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEf5SawBueyAVt7khTxzsu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEf5SawBueyAVt7khTxzsu)_