### PR TITLE
seo: give /temas topic pages their own Open Graph tags

### DIFF
--- a/site/app/temas/[slug]/page.tsx
+++ b/site/app/temas/[slug]/page.tsx
@@ -60,10 +60,25 @@ export async function generateMetadata({ params }: Props) {
   const { slug } = await params
   const t = getTopic(slug)
   if (!t) return {}
+  const description = t.intro.slice(0, 180)
   return {
     title: t.title,
-    description: t.intro.slice(0, 180),
+    description,
     alternates: { canonical: `${SITE}/temas/${t.slug}` },
+    // Next's metadata merge is shallow per top-level key: a page that sets
+    // its own `openGraph` (as this one now must, to carry topic-specific
+    // title/description/url instead of the root layout's homepage-generic
+    // ones) fully replaces the root layout's `openGraph` object rather than
+    // merging into it — so siteName/locale have to be repeated here too, or
+    // they silently drop, matching app/layout.tsx's literals.
+    openGraph: {
+      type: 'website',
+      siteName: 'LeyChile',
+      locale: 'es_CL',
+      title: t.title,
+      description,
+      url: `${SITE}/temas/${t.slug}`,
+    },
   }
 }
 


### PR DESCRIPTION
## Problem

`/temas/{slug}` never set its own `openGraph`, so every topic page (Ley Karin, arriendo, consumidor, ...) fell back to the root layout's generic `openGraph` object — `og:title`, `og:description` and `og:url` all showed the sitewide homepage blurb instead of the topic, on every social share.

Confirmed live before this fix (all 9 topic pages identical):
```
$ curl -s https://leyes.pisanvs.cl/temas/ley-karin | grep -E 'og:title|og:url'
<meta property="og:title" content="El corpus jurídico chileno, en formato amigable"/>
<meta property="og:url" content="https://leyes.pisanvs.cl"/>
```
i.e. sharing a link to the Ley Karin topic page on Twitter/Slack/WhatsApp previews as the homepage, not the topic.

Note `title`/`description`/`alternates.canonical` on this route were already correct — only `openGraph` was missing.

## Fix

Set `openGraph.{title,description,url,type}` from the same topic data already used for the top-level `title`/`description`, matching the pattern every sibling content route (`guia`/`cambios`/`blog`) uses. `siteName`/`locale` are repeated explicitly (matching `app/layout.tsx`'s literals) because Next's metadata merge replaces `openGraph` wholesale per route rather than deep-merging it — a page defining its own `openGraph` loses the root layout's `siteName`/`locale` unless it restates them.

## Verification

Run from `site/`, with no `DATABASE_URL` set:

```
$ pnpm build
✓ Compiled successfully, all routes generated

$ npx tsc --noEmit
(clean, no output)

$ pnpm vitest run
 Test Files  21 passed | 1 skipped (22)
      Tests  142 passed | 1 skipped (143)
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEf5SawBueyAVt7khTxzsu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEf5SawBueyAVt7khTxzsu)_