### PR TITLE
seo: fix llms.txt documenting a sitemap URL that 404s

### DIFF
--- a/site/app/llms.txt/route.ts
+++ b/site/app/llms.txt/route.ts
@@ -55,7 +55,7 @@ usa search_articles para ubicar el artículo relevante primero.
 - ${SITE}/api/text/{idNorma}/{fecha}   — texto markdown reconstruido de una versión
 - ${SITE}/api/idx/modifies/{idNorma}   — normas que ESTA modificó (JSON)
 - ${SITE}/api/idx/modified_by/{idNorma}— normas que modificaron a ESTA (JSON)
-- ${SITE}/sitemap.xml                  — índice de sitemaps
+- ${SITE}/robots.txt                   — lista todos los sitemaps (no hay índice único en /sitemap.xml)
 
 \`tipo\` ∈ ley, dl, dfl, dto, cod, res, … · \`numero\` es el número de la norma
 (no el idNorma interno). Ojo: algunos numeros contienen caracteres especiales


### PR DESCRIPTION
## Problem

`/llms.txt` told agents to fetch `${SITE}/sitemap.xml` for the sitemap index. That path has never existed by design — `app/robots.ts`'s own comment explains that Next's `generateSitemaps()` convention serves shards at `/sitemap/{id}.xml` with no index at the bare `/sitemap.xml`, so every shard is listed directly in `robots.txt` instead.

Confirmed live:
```
$ curl -s -o /dev/null -w '%{http_code}' https://leyes.pisanvs.cl/sitemap.xml
404
```

## Fix

Point agents at `/robots.txt` instead, which actually lists every sitemap (the 32 law-URL shards plus `sitemap-contenido.xml`).

While auditing this file, I also cross-checked every documented MCP tool name/signature (`search_laws`, `get_law`, `get_article`, `list_versions`, `get_raw_link`, `diff_versions`, `get_modifications`, `search_articles`) against the live server via the MCP connector — all still match, no further changes needed there.

## Verification

Run from `site/`, with no `DATABASE_URL` set:

```
$ pnpm build
✓ Compiled successfully, all routes generated

$ npx tsc --noEmit
(clean, no output)

$ pnpm vitest run
 Test Files  21 passed | 1 skipped (22)
      Tests  142 passed | 1 skipped (143)
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEf5SawBueyAVt7khTxzsu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEf5SawBueyAVt7khTxzsu)_