### PR TITLE
feat(api): public docs page at /api and an OpenAPI 3.1 spec

### DIFF
--- a/site/app/api/page.tsx
+++ b/site/app/api/page.tsx
@@ -1,0 +1,653 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { SITE } from '@/lib/site'
+import { CopyBlock } from '@/components/CopyBlock'
+
+/**
+ * Public documentation for the REST API, at /api.
+ *
+ * Structure borrowed from Stripe's and Vercel's references — a sticky endpoint
+ * nav, method-and-path as the section heading, parameters as a definition list
+ * rather than a table (a 4-column table is unreadable at narrow widths), and a
+ * real response body beside every endpoint instead of in an appendix.
+ *
+ * The look is this site's own: warm paper rather than the dark code slabs those
+ * references use, Fraunces for headings, JetBrains Mono for code. A docs page
+ * in a foreign visual language reads as a bolted-on afterthought.
+ *
+ * Deliberately public — a prospective consumer has to read this BEFORE they
+ * have a key, so requiring one would be circular. No database access, so it
+ * prerenders as static content.
+ */
+
+export const metadata: Metadata = {
+  title: 'API — el corpus jurídico chileno en JSON',
+  description:
+    'API REST de sólo lectura sobre las 333.026 normas chilenas: búsqueda, articulado, ' +
+    'versiones históricas y diffs entre ellas. Autenticada con API key.',
+  alternates: { canonical: `${SITE}/api` },
+}
+
+const BASE = `${SITE}/api/v1`
+
+interface Param {
+  name: string
+  type: string
+  required?: boolean
+  desc: string
+}
+
+interface Endpoint {
+  id: string
+  path: string
+  title: string
+  blurb: string
+  params?: Param[]
+  req: string
+  res: string
+  note?: string
+}
+
+const ENDPOINTS: Endpoint[] = [
+  {
+    id: 'search',
+    path: '/search',
+    title: 'Buscar en el corpus',
+    blurb:
+      'Texto libre con `q`, o una cita con `tipo` + `numero`. Una cita devuelve todas las ' +
+      'candidatas, nunca una adivinanza.',
+    params: [
+      { name: 'q', type: 'string', desc: 'Términos de búsqueda, mínimo 2 caracteres.' },
+      { name: 'tipo', type: 'string', desc: 'Tipo de cita: ley, dl, dfl, dto, cod, res…' },
+      { name: 'numero', type: 'string', desc: 'Número de la norma. Requiere `tipo`.' },
+      { name: 'asOf', type: 'date', desc: 'YYYY-MM-DD. Busca el texto vigente a esa fecha. Por defecto hoy.' },
+      { name: 'limit', type: 'integer', desc: '1–100, por defecto 20. Sólo en texto libre: una cita siempre devuelve todo.' },
+    ],
+    req: `curl -H "Authorization: Bearer $LEYCHILE_KEY" \\
+  '${BASE}/search?q=medio+ambiente&limit=2'`,
+    res: `{
+  "query": "medio ambiente",
+  "asOf": "2026-09-10",
+  "total": 2,
+  "resultados": [
+    {
+      "idNorma": 30667,
+      "tipo": "ley",
+      "numero": "19300",
+      "titulo": "APRUEBA LEY SOBRE BASES GENERALES DEL MEDIO AMBIENTE",
+      "organismo": "MINISTERIO SECRETARÍA GENERAL DE LA PRESIDENCIA"
+    }
+  ]
+}`,
+  },
+  {
+    id: 'norma',
+    path: '/normas/{idNorma}',
+    title: 'Una norma y su índice de artículos',
+    blurb:
+      'Metadatos más el índice de artículos. **Nunca** el texto de los artículos: una norma ' +
+      'puede pesar ~350 KB, así que los cuerpos se piden de uno en uno.',
+    params: [
+      { name: 'idNorma', type: 'integer', required: true, desc: 'En la ruta. El identificador único de LeyChile.' },
+      { name: 'fecha', type: 'date', desc: 'YYYY-MM-DD. Devuelve la versión vigente a esa fecha.' },
+    ],
+    req: `curl -H "Authorization: Bearer $LEYCHILE_KEY" \\
+  '${BASE}/normas/29994'`,
+    res: `{
+  "idNorma": 29994,
+  "tipo": "ley",
+  "numero": "18603",
+  "titulo": "LEY ORGANICA CONSTITUCIONAL DE LOS PARTIDOS POLITICOS",
+  "organismo": "MINISTERIO DEL INTERIOR",
+  "derogado": false,
+  "fechaPublicacion": "1987-03-23",
+  "fecha": "2016-04-15",
+  "totalVersiones": 6,
+  "articulos": [
+    { "slug": "art-1", "label": "articulo 1", "rawHeading": "Artículo 1º" }
+  ]
+}`,
+  },
+  {
+    id: 'articulos',
+    path: '/normas/{idNorma}/articulos',
+    title: 'Índice de artículos, o buscar dentro de la norma',
+    blurb:
+      'Sin `q`, el índice completo a una fecha. Con `q`, sólo los artículos que coinciden, ' +
+      'cada uno con un `snippet`. Así se ubica el artículo relevante de un código con ' +
+      'cientos sin descargar su texto.',
+    params: [
+      { name: 'idNorma', type: 'integer', required: true, desc: 'En la ruta.' },
+      { name: 'q', type: 'string', desc: 'Términos a buscar dentro de la norma, mínimo 2 caracteres.' },
+      { name: 'fecha', type: 'date', desc: 'YYYY-MM-DD. Por defecto la versión vigente.' },
+    ],
+    req: `curl -H "Authorization: Bearer $LEYCHILE_KEY" \\
+  '${BASE}/normas/29994/articulos?q=militante'`,
+    res: `{
+  "idNorma": 29994,
+  "fecha": "2016-04-15",
+  "query": "militante",
+  "total": 5,
+  "articulos": [
+    {
+      "slug": "art-23-bis",
+      "label": "articulo 23 bis",
+      "rawHeading": "Artículo 23 bis",
+      "snippet": "…sus <b>militantes</b>. La infracción de esta prohibición…"
+    }
+  ]
+}`,
+  },
+  {
+    id: 'articulo',
+    path: '/normas/{idNorma}/articulos/{slug}',
+    title: 'El texto de un artículo',
+    blurb:
+      'Los cuerpos se cortan a 12.000 caracteres. Cuando `truncado` es `true` el texto está ' +
+      'incompleto y `largoCompleto` da el largo real — nunca tomes un artículo truncado por ' +
+      'el precepto entero.',
+    params: [
+      { name: 'idNorma', type: 'integer', required: true, desc: 'En la ruta.' },
+      { name: 'slug', type: 'string', required: true, desc: 'En la ruta. Del índice de artículos.' },
+      { name: 'fecha', type: 'date', desc: 'YYYY-MM-DD. Por defecto la versión vigente.' },
+    ],
+    req: `curl -H "Authorization: Bearer $LEYCHILE_KEY" \\
+  '${BASE}/normas/29994/articulos/art-1'`,
+    res: `{
+  "idNorma": 29994,
+  "fecha": "2016-04-15",
+  "slug": "art-1",
+  "label": "articulo 1",
+  "rawHeading": "Artículo 1º",
+  "body": "Los partidos políticos son asociaciones autónomas y voluntarias…",
+  "truncado": false,
+  "largoCompleto": 970
+}`,
+  },
+  {
+    id: 'versiones',
+    path: '/normas/{idNorma}/versiones',
+    title: 'Historial de versiones',
+    blurb:
+      'Cada versión con la ventana en que rigió. Los `desde` son las fechas que se pasan como ' +
+      '`fecha`, `from` y `to` en el resto de la API.',
+    params: [{ name: 'idNorma', type: 'integer', required: true, desc: 'En la ruta.' }],
+    req: `curl -H "Authorization: Bearer $LEYCHILE_KEY" \\
+  '${BASE}/normas/1984/versiones'`,
+    res: `{
+  "idNorma": 1984,
+  "vigente": "2025-09-17",
+  "total": 122,
+  "versiones": [
+    {
+      "desde": "1874-11-12",
+      "hasta": "1917-09-26",
+      "causaId": null,
+      "subject": "Código Penal publicada (1874-11-12)"
+    }
+  ]
+}`,
+    note: 'El Código Penal tiene 122 versiones desde 1874. Ése es el punto del corpus.',
+  },
+  {
+    id: 'diff',
+    path: '/normas/{idNorma}/diff',
+    title: 'Qué cambió entre dos versiones',
+    blurb:
+      'La pregunta para la que existe este corpus. Devuelve operaciones estructuradas por ' +
+      'artículo, no prosa. Una norma que no cambió devuelve `200` con `cambios` vacío: eso es ' +
+      'una respuesta, no un error.',
+    params: [
+      { name: 'idNorma', type: 'integer', required: true, desc: 'En la ruta.' },
+      { name: 'from', type: 'date', required: true, desc: 'YYYY-MM-DD. La versión anterior.' },
+      { name: 'to', type: 'date', required: true, desc: 'YYYY-MM-DD. La versión posterior.' },
+    ],
+    req: `curl -H "Authorization: Bearer $LEYCHILE_KEY" \\
+  '${BASE}/normas/29994/diff?from=2015-05-05&to=2016-04-15'`,
+    res: `{
+  "idNorma": 29994,
+  "from": "2015-05-05",
+  "to": "2016-04-15",
+  "resumen": { "modificados": 53, "añadidos": 16, "eliminados": 0 },
+  "cambios": [
+    {
+      "slug": "art-1",
+      "rawHeading": "Artículo 1º",
+      "estado": "modificado",
+      "ops": [
+        { "op": "delete", "text": "voluntarias, dotadas de personalidad jurídica…" },
+        { "op": "insert", "text": "autónomas y voluntarias organizadas democráticamente…" }
+      ]
+    }
+  ]
+}`,
+  },
+  {
+    id: 'modificaciones',
+    path: '/normas/{idNorma}/modificaciones',
+    title: 'El grafo de modificaciones, en ambos sentidos',
+    blurb:
+      'Qué normas modificaron a ésta, y a cuáles modificó ella. Cada entrada trae su ' +
+      '`idNorma`, así que nunca hay que resolver una cita ambigua.',
+    params: [{ name: 'idNorma', type: 'integer', required: true, desc: 'En la ruta.' }],
+    req: `curl -H "Authorization: Bearer $LEYCHILE_KEY" \\
+  '${BASE}/normas/29994/modificaciones'`,
+    res: `{
+  "idNorma": 29994,
+  "modifica": [],
+  "modificadaPor": [
+    {
+      "idNorma": 1089164,
+      "tipo": "ley",
+      "numero": "20915",
+      "titulo": "FORTALECE EL CARÁCTER PÚBLICO Y DEMOCRÁTICO DE LOS PARTIDOS POLÍTICOS…",
+      "fecha": "2016-04-15"
+    }
+  ]
+}`,
+  },
+  {
+    id: 'raw',
+    path: '/normas/{idNorma}/raw',
+    title: 'El enlace a la fuente autoritativa',
+    blurb: 'Enlaces de vuelta a leychile.cl, para citar o verificar una versión.',
+    params: [
+      { name: 'idNorma', type: 'integer', required: true, desc: 'En la ruta.' },
+      { name: 'fecha', type: 'date', desc: 'YYYY-MM-DD. Por defecto la versión vigente.' },
+    ],
+    req: `curl -H "Authorization: Bearer $LEYCHILE_KEY" \\
+  '${BASE}/normas/29994/raw?fecha=2016-04-15'`,
+    res: `{
+  "idNorma": 29994,
+  "fecha": "2016-04-15",
+  "url": "https://www.leychile.cl/Navegar?idNorma=29994&idVersion=2016-04-15",
+  "xml": "https://www.leychile.cl/Consulta/obtxml?opt=7&idNorma=29994&idVersion=2016-04-15"
+}`,
+  },
+]
+
+const ERRORS: [string, string, string][] = [
+  ['400', 'bad_request', '`idNorma` o fecha mal formada, o falta un parámetro obligatorio.'],
+  ['401', 'missing_api_key · invalid_api_key', 'Key ausente, desconocida o revocada.'],
+  ['404', 'not_found', 'No existe esa norma, artículo o versión.'],
+  ['503', 'service_unavailable', 'Servicio temporalmente no disponible.'],
+]
+
+/** Minimal inline markup: `code` and **strong**. Enough for this page's prose,
+ *  and cheaper than pulling a markdown renderer into a static page. */
+function rich(s: string) {
+  return s.split(/(`[^`]+`|\*\*[^*]+\*\*)/g).map((part, i) => {
+    if (part.startsWith('`')) {
+      return (
+        <code key={i} className="font-mono text-[0.9em] text-indigo">
+          {part.slice(1, -1)}
+        </code>
+      )
+    }
+    if (part.startsWith('**')) {
+      return (
+        <strong key={i} className="text-ink font-semibold">
+          {part.slice(2, -2)}
+        </strong>
+      )
+    }
+    return part
+  })
+}
+
+function Section({
+  id,
+  eyebrow,
+  title,
+  children,
+}: {
+  id: string
+  eyebrow?: string
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <section id={id} className="scroll-mt-8 border-t border-rule pt-10 mt-14 first:mt-0 first:border-0 first:pt-0">
+      {eyebrow && (
+        <p className="text-[10.5px] uppercase tracking-[0.25em] text-ink-faint mb-3">{eyebrow}</p>
+      )}
+      <h2 className="font-display text-2xl md:text-[1.75rem] leading-tight text-balance mb-4">
+        {title}
+      </h2>
+      {children}
+    </section>
+  )
+}
+
+export default function Page() {
+  return (
+    <div className="flex-1 overflow-y-auto scrollbar-quiet">
+      <div className="px-6 md:px-12 max-w-6xl mx-auto pt-16 pb-24">
+        {/* ── Masthead ─────────────────────────────────────────────── */}
+        <header className="max-w-3xl">
+          <p className="text-[10.5px] uppercase tracking-[0.25em] text-ink-faint mb-5">
+            API · v1
+          </p>
+          <h1 className="font-display text-4xl md:text-[3.25rem] leading-[1.05] tracking-tight text-balance">
+            El corpus jurídico chileno, <span className="text-ruby">en JSON</span>.
+          </h1>
+          <p className="mt-6 text-ink-soft text-[15.5px] leading-relaxed">
+            333.026 normas, cada versión histórica de cada una, y el grafo de modificaciones
+            entre ellas. Sólo lectura, autenticada con una API key. Los mismos datos que
+            entrega el{' '}
+            <a href="/api/mcp" className="text-indigo underline underline-offset-2 hover:text-ruby transition-colors">
+              servidor MCP
+            </a>
+            {' '}— ése devuelve prosa para modelos, ésta devuelve JSON.
+          </p>
+
+          <div className="mt-7 flex flex-wrap items-center gap-2.5">
+            <code className="font-mono text-[12.5px] bg-paper-sunk border border-rule rounded-md px-2.5 py-1.5 text-ink-soft">
+              {BASE}
+            </code>
+            <a
+              href="/api/v1/openapi.json"
+              className="text-xs font-ui px-3 py-1.5 rounded-md border border-rule text-ink-soft hover:text-ink hover:border-ink/40 transition"
+            >
+              OpenAPI 3.1
+            </a>
+            <a
+              href="/llms.txt"
+              className="text-xs font-ui px-3 py-1.5 rounded-md border border-rule text-ink-soft hover:text-ink hover:border-ink/40 transition"
+            >
+              llms.txt
+            </a>
+          </div>
+        </header>
+
+        <div className="mt-16 lg:grid lg:grid-cols-[1fr_13rem] lg:gap-14 items-start">
+          {/* ── Content ────────────────────────────────────────────── */}
+          <main className="min-w-0 max-w-3xl">
+            <Section id="auth" eyebrow="Empezar" title="Autenticación">
+              <p className="text-ink-soft text-[15px] leading-relaxed mb-5">
+                {rich(
+                  'Todos los endpoints exigen una key. Las emite el operador a mano — pídela. ' +
+                  'Una key ausente, desconocida o revocada devuelve `401`.',
+                )}
+              </p>
+              <CopyBlock
+                caption="Cabecera"
+                code={`Authorization: Bearer lc_live_…`}
+                lang="http"
+              />
+              <p className="text-ink-faint text-[13.5px] leading-relaxed mt-4">
+                {rich(
+                  'De la key sólo se guarda su SHA-256, así que se muestra una única vez al ' +
+                  'emitirla y después es irrecuperable. Guárdala como cualquier otro secreto.',
+                )}
+              </p>
+            </Section>
+
+            <Section id="idnorma" eyebrow="Lo primero que hay que entender" title="idNorma es el identificador que sirve">
+              <p className="text-ink-soft text-[15px] leading-relaxed">
+                {rich(
+                  '**`(tipo, numero)` no identifica una norma chilena.** Hay 227 normas que son ' +
+                  '“DFL 1”, 75 que son “DFL 4” y 525 que son “DTO 1”, de distintos organismos y ' +
+                  'años. Peor: un `idNorma` interno puede coincidir con el `numero` de una ley sin ' +
+                  'relación — `/ley/20780` llegó a resolver a un decreto cuyo `idNorma` era 20780.',
+                )}
+              </p>
+              <p className="text-ink-soft text-[15px] leading-relaxed mt-4 mb-5">
+                {rich(
+                  'Por eso toda la API direcciona por `idNorma`, y una búsqueda por cita devuelve ' +
+                  '**todas** las candidatas en vez de adivinar. Elige la que querías por su ' +
+                  '`idNorma` y `organismo`, y usa ese `idNorma` de ahí en adelante.',
+                )}
+              </p>
+              <CopyBlock
+                code={`curl -H "Authorization: Bearer $LEYCHILE_KEY" \\
+  '${BASE}/search?tipo=dfl&numero=1'`}
+              />
+            </Section>
+
+            {/* ── Endpoints ─────────────────────────────────────────── */}
+            <div className="border-t border-rule pt-10 mt-14">
+              <p className="text-[10.5px] uppercase tracking-[0.25em] text-ink-faint mb-3">
+                Referencia
+              </p>
+              <h2 className="font-display text-2xl md:text-[1.75rem] leading-tight mb-2">
+                Endpoints
+              </h2>
+              <p className="text-ink-soft text-[14.5px] leading-relaxed">
+                Ocho, todos <code className="font-mono text-[0.9em] text-indigo">GET</code>, todos
+                relativos a <code className="font-mono text-[0.9em] text-ink-soft">{BASE}</code>.
+              </p>
+            </div>
+
+            {ENDPOINTS.map((e) => (
+              <section key={e.id} id={e.id} className="scroll-mt-8 mt-12 pt-8 border-t border-rule/60">
+                <div className="flex items-baseline gap-2.5 flex-wrap mb-2.5">
+                  <span className="font-mono text-[10px] uppercase tracking-[0.12em] px-1.5 py-0.5 rounded bg-ruby-soft text-ruby">
+                    GET
+                  </span>
+                  <code className="font-mono text-[13.5px] text-ink break-all">{e.path}</code>
+                </div>
+                <h3 className="font-display text-[1.3rem] leading-snug mb-2.5">{e.title}</h3>
+                <p className="text-ink-soft text-[14.5px] leading-relaxed max-w-2xl">
+                  {rich(e.blurb)}
+                </p>
+
+                {e.params && (
+                  <dl className="mt-6 space-y-3.5">
+                    {e.params.map((p) => (
+                      <div key={p.name}>
+                        <dt className="flex items-baseline gap-2 flex-wrap">
+                          <code className="font-mono text-[13px] text-ink">{p.name}</code>
+                          <span className="font-ui text-[10.5px] uppercase tracking-[0.12em] text-ink-faint">
+                            {p.type}
+                          </span>
+                          {p.required && (
+                            <span className="font-ui text-[10.5px] uppercase tracking-[0.12em] text-ruby">
+                              obligatorio
+                            </span>
+                          )}
+                        </dt>
+                        <dd className="text-ink-soft text-[13.5px] leading-relaxed mt-0.5">
+                          {rich(p.desc)}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                )}
+
+                <div className="mt-6 grid gap-3 xl:grid-cols-2">
+                  <CopyBlock code={e.req} />
+                  <CopyBlock code={e.res} lang="json" />
+                </div>
+
+                {e.note && (
+                  <p className="mt-3.5 font-display italic text-[14px] text-ink-faint">{e.note}</p>
+                )}
+              </section>
+            ))}
+
+            <Section id="errores" eyebrow="Comportamiento" title="Errores">
+              <p className="text-ink-soft text-[15px] leading-relaxed mb-5">
+                {rich('Siempre la misma envoltura, con el código HTTP que corresponde.')}
+              </p>
+              <CopyBlock
+                lang="json"
+                caption="Envoltura"
+                code={`{ "error": { "code": "invalid_api_key", "message": "…" } }`}
+              />
+              <dl className="mt-6 space-y-3">
+                {ERRORS.map(([status, code, desc]) => (
+                  <div key={status} className="flex gap-4">
+                    <dt className="font-mono text-[13px] text-ruby w-9 shrink-0">{status}</dt>
+                    <dd className="min-w-0">
+                      <code className="font-mono text-[12.5px] text-ink-soft">{code}</code>
+                      <p className="text-ink-soft text-[13.5px] leading-relaxed mt-0.5">{rich(desc)}</p>
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+              <p className="text-ink-soft text-[14.5px] leading-relaxed mt-6">
+                {rich(
+                  'Un arreglo `resultados` o `cambios` vacío significa **que no hubo coincidencias**. ' +
+                  'Nunca significa que el servicio esté roto: eso siempre es un `4xx` o un `5xx`.',
+                )}
+              </p>
+              <p className="text-ink-soft text-[14.5px] leading-relaxed mt-3">
+                {rich(
+                  'Las fechas tienen que ser fechas reales del calendario: `2026-02-31` es un `400`, ' +
+                  'no una sustitución silenciosa.',
+                )}
+              </p>
+            </Section>
+
+            <Section id="cache" eyebrow="Comportamiento" title="Caché">
+              <p className="text-ink-soft text-[15px] leading-relaxed mb-5">
+                {rich(
+                  'Las lecturas de norma, artículo y versiones traen `ETag` y ' +
+                  '`Cache-Control: private, max-age=300`. Devuelve el ETag como `If-None-Match` ' +
+                  'y obtienes un `304` sin cuerpo.',
+                )}
+              </p>
+              <CopyBlock
+                code={`curl -H "Authorization: Bearer $LEYCHILE_KEY" \\
+     -H 'If-None-Match: "82b8be35b76e4fdcfa40263691e1b912"' \\
+  '${BASE}/normas/29994'`}
+              />
+              <p className="text-ink-faint text-[13.5px] leading-relaxed mt-4">
+                {rich(
+                  '`private` es deliberado: las respuestas van detrás de una cabecera ' +
+                  '`Authorization` y no deben quedar en una caché compartida. La búsqueda no se ' +
+                  'cachea.',
+                )}
+              </p>
+            </Section>
+
+            <Section id="registro" eyebrow="Transparencia" title="Qué se registra">
+              <p className="text-ink-soft text-[15px] leading-relaxed">
+                {rich(
+                  'Por cada petición: **la API key, la plantilla de ruta, el código HTTP, la ' +
+                  'duración y la hora.**',
+                )}
+              </p>
+              <p className="text-ink-soft text-[15px] leading-relaxed mt-4">
+                {rich(
+                  '**No se registra:** qué buscaste, qué norma o artículo pediste, tu dirección IP, ' +
+                  'ni tu user agent.',
+                )}
+              </p>
+              <div className="mt-6 rounded-lg border border-rule bg-paper-sunk px-4 py-3.5">
+                <p className="text-ink-soft text-[13.5px] leading-relaxed">
+                  {rich(
+                    'Se guarda la plantilla — `/v1/normas/{idNorma}` — nunca la ruta concreta. ' +
+                    'Registrar `/v1/normas/29994` construiría un historial de qué leyes lee cada ' +
+                    'titular de una key, y esta API no lo conserva. Las filas de uso se borran a ' +
+                    'los **90 días**.',
+                  )}
+                </p>
+              </div>
+              <p className="text-ink-faint text-[13.5px] leading-relaxed mt-4">
+                {rich(
+                  'El corpus en sí es público y no recoge ninguna dimensión de usuario. La key ' +
+                  'existe para que el operador vea volumen de llamadas y pueda revocar abusos, no ' +
+                  'para seguir lecturas.',
+                )}
+              </p>
+            </Section>
+
+            <Section id="limites" eyebrow="Antes de integrar" title="Límites y detalles">
+              <ul className="space-y-3 text-ink-soft text-[14.5px] leading-relaxed">
+                <li className="flex gap-3">
+                  <span className="text-ink-faint shrink-0">—</span>
+                  <span>
+                    {rich(
+                      'Hoy no hay límite de tasa ni cuota. Puede cambiar si crece el tráfico, y se ' +
+                      'avisaría antes. Sé razonable: son 333k normas servidas por una instancia chica.',
+                    )}
+                  </span>
+                </li>
+                <li className="flex gap-3">
+                  <span className="text-ink-faint shrink-0">—</span>
+                  <span>
+                    {rich(
+                      'No se envían cabeceras CORS, así que un navegador no puede llamar a esta API ' +
+                      'entre orígenes. Está pensada para servidor a servidor.',
+                    )}
+                  </span>
+                </li>
+                <li className="flex gap-3">
+                  <span className="text-ink-faint shrink-0">—</span>
+                  <span>
+                    {rich(
+                      'Los nombres de campo usan los términos del dominio en español (`titulo`, ' +
+                      '`numero`, `articulos`, `versiones`). `norma`, `dfl` y `dto` no tienen ' +
+                      'equivalente honesto en inglés.',
+                    )}
+                  </span>
+                </li>
+                <li className="flex gap-3">
+                  <span className="text-ink-faint shrink-0">—</span>
+                  <span>
+                    {rich(
+                      'Los datos derivan de leychile.cl y se reconstruyen desde un historial git del ' +
+                      'corpus. `/raw` enlaza de vuelta a la fuente autoritativa.',
+                    )}
+                  </span>
+                </li>
+              </ul>
+              <p className="text-ink-soft text-[14.5px] leading-relaxed mt-7">
+                Todo esto también está en{' '}
+                <a
+                  href="/api/v1/openapi.json"
+                  className="text-indigo underline underline-offset-2 hover:text-ruby transition-colors"
+                >
+                  OpenAPI 3.1
+                </a>
+                , si prefieres generar un cliente.{' '}
+                <Link href="/" className="text-indigo underline underline-offset-2 hover:text-ruby transition-colors">
+                  Volver al lector
+                </Link>
+                .
+              </p>
+            </Section>
+          </main>
+
+          {/* ── Sticky nav ─────────────────────────────────────────── */}
+          <nav
+            aria-label="Contenidos"
+            className="hidden lg:block sticky top-8 text-[12.5px] font-ui"
+          >
+            <p className="text-[10px] uppercase tracking-[0.2em] text-ink-faint mb-3">
+              En esta página
+            </p>
+            <ul className="space-y-1.5 border-l border-rule pl-3.5">
+              <li><a href="#auth" className="text-ink-soft hover:text-ruby transition-colors">Autenticación</a></li>
+              <li><a href="#idnorma" className="text-ink-soft hover:text-ruby transition-colors">idNorma</a></li>
+            </ul>
+            <p className="text-[10px] uppercase tracking-[0.2em] text-ink-faint mt-5 mb-3">
+              Endpoints
+            </p>
+            <ul className="space-y-1.5 border-l border-rule pl-3.5">
+              {ENDPOINTS.map((e) => (
+                <li key={e.id}>
+                  <a href={`#${e.id}`} className="font-mono text-[11.5px] text-ink-soft hover:text-ruby transition-colors break-all">
+                    {e.path.replace('/normas/{idNorma}', '…')}
+                  </a>
+                </li>
+              ))}
+            </ul>
+            <p className="text-[10px] uppercase tracking-[0.2em] text-ink-faint mt-5 mb-3">
+              Detalles
+            </p>
+            <ul className="space-y-1.5 border-l border-rule pl-3.5">
+              <li><a href="#errores" className="text-ink-soft hover:text-ruby transition-colors">Errores</a></li>
+              <li><a href="#cache" className="text-ink-soft hover:text-ruby transition-colors">Caché</a></li>
+              <li><a href="#registro" className="text-ink-soft hover:text-ruby transition-colors">Qué se registra</a></li>
+              <li><a href="#limites" className="text-ink-soft hover:text-ruby transition-colors">Límites</a></li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/site/app/api/v1/openapi.json/route.ts
+++ b/site/app/api/v1/openapi.json/route.ts
@@ -1,0 +1,473 @@
+import { SITE } from '@/lib/site'
+
+/**
+ * OpenAPI 3.1 description of the public API.
+ *
+ * Deliberately UNAUTHENTICATED: a schema is not corpus data, and a consumer
+ * needs to read it before they have a key. It is also the one endpoint that
+ * must not require the thing it documents how to obtain.
+ *
+ * Hand-written rather than generated. The route handlers are plain functions
+ * with no schema decorators to derive from, so generating it would mean adding
+ * a validation layer purely to feed a document — and a wrong-but-generated
+ * schema is worse than an accurate hand-written one. The trade is that this
+ * file must be updated alongside any endpoint change; the eight paths below
+ * mirror `KNOWN_ENDPOINTS` in lib/apiusage.ts, which a test already pins.
+ */
+
+const IDNORMA_PARAM = {
+  name: 'idNorma',
+  in: 'path' as const,
+  required: true,
+  schema: { type: 'integer' as const, minimum: 1 },
+  description:
+    'LeyChile\'s unique identifier. Use this rather than (tipo, numero), which is not unique — ' +
+    '227 normas share "DFL 1". Obtain it from /search.',
+  example: 29994,
+}
+
+const FECHA_PARAM = {
+  name: 'fecha',
+  in: 'query' as const,
+  required: false,
+  schema: { type: 'string' as const, format: 'date' as const },
+  description: 'YYYY-MM-DD. Returns the text in force on that date. Defaults to the current version.',
+  example: '2016-04-15',
+}
+
+const ERRORS = {
+  BadRequest: { $ref: '#/components/responses/BadRequest' },
+  Unauthorized: { $ref: '#/components/responses/Unauthorized' },
+  NotFound: { $ref: '#/components/responses/NotFound' },
+  Unavailable: { $ref: '#/components/responses/Unavailable' },
+}
+
+const errorResponse = (description: string) => ({
+  description,
+  content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } },
+})
+
+const spec = {
+  openapi: '3.1.0',
+  info: {
+    title: 'LeyChile API',
+    version: '1.0.0',
+    description:
+      'Read-only JSON API over the Chilean legal corpus: 333,026 normas, every historical ' +
+      'version of each, and the modification graph between them.\n\n' +
+      '`(tipo, numero)` does not identify a Chilean norma — always address them by `idNorma`.\n\n' +
+      'Logged per request: the API key, the route template, the status, the duration and the ' +
+      'timestamp. Not logged: search terms, which norma was read, IP, or user agent. Usage rows ' +
+      'are deleted after 90 days.',
+    contact: { url: `${SITE}/api` },
+  },
+  servers: [{ url: `${SITE}/api/v1`, description: 'Production' }],
+  security: [{ bearerAuth: [] }],
+  tags: [
+    { name: 'search', description: 'Find normas across the corpus' },
+    { name: 'normas', description: 'Read one norma, its articles, versions and relations' },
+  ],
+  paths: {
+    '/search': {
+      get: {
+        tags: ['search'],
+        summary: 'Search the corpus by text or citation',
+        description:
+          'Either free text (`q`) or a citation (`tipo` + `numero`). A citation returns EVERY ' +
+          'candidate rather than guessing, because (tipo, numero) is ambiguous across most of ' +
+          'the corpus.',
+        operationId: 'search',
+        parameters: [
+          { name: 'q', in: 'query', schema: { type: 'string', minLength: 2 },
+            description: 'Free-text terms, minimum 2 characters.', example: 'medio ambiente' },
+          { name: 'tipo', in: 'query', schema: { type: 'string' },
+            description: 'Citation type: ley, dl, dfl, dto, cod, res…', example: 'ley' },
+          { name: 'numero', in: 'query', schema: { type: 'string' },
+            description: 'Citation number. Requires `tipo`.', example: '18603' },
+          { name: 'asOf', in: 'query', schema: { type: 'string', format: 'date' },
+            description: 'YYYY-MM-DD. Searches the text in force on that date. Defaults to today.' },
+          { name: 'limit', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
+            description: 'Free-text only. A citation always returns every candidate.' },
+        ],
+        responses: {
+          200: {
+            description: 'Matching normas.',
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/SearchResult' } } },
+          },
+          400: ERRORS.BadRequest, 401: ERRORS.Unauthorized, 503: ERRORS.Unavailable,
+        },
+      },
+    },
+    '/normas/{idNorma}': {
+      get: {
+        tags: ['normas'],
+        summary: 'Norma metadata and article index',
+        description:
+          'Metadata plus an index of article slugs. Never article bodies — a single norma can ' +
+          'be ~350 KB. Fetch bodies one at a time from /normas/{idNorma}/articulos/{slug}.',
+        operationId: 'getNorma',
+        parameters: [IDNORMA_PARAM, FECHA_PARAM],
+        responses: {
+          200: {
+            description: 'The norma.',
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/Norma' } } },
+            headers: {
+              ETag: { schema: { type: 'string' }, description: 'Send back as If-None-Match for a 304.' },
+            },
+          },
+          304: { description: 'Not modified — the ETag you sent still matches.' },
+          400: ERRORS.BadRequest, 401: ERRORS.Unauthorized, 404: ERRORS.NotFound, 503: ERRORS.Unavailable,
+        },
+      },
+    },
+    '/normas/{idNorma}/articulos': {
+      get: {
+        tags: ['normas'],
+        summary: 'Article index, or search within the norma',
+        description:
+          'Without `q`, the full article index at a date. With `q`, only matching articles, ' +
+          'each carrying a `snippet` with <b> around the hit — how to locate the relevant ' +
+          'article of a code with hundreds of them without downloading its text.',
+        operationId: 'listArticulos',
+        parameters: [
+          IDNORMA_PARAM, FECHA_PARAM,
+          { name: 'q', in: 'query', schema: { type: 'string', minLength: 2 },
+            description: 'Search terms, minimum 2 characters.', example: 'militante' },
+        ],
+        responses: {
+          200: {
+            description: 'Article index, with snippets when `q` is given.',
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/ArticuloList' } } },
+          },
+          400: ERRORS.BadRequest, 401: ERRORS.Unauthorized, 404: ERRORS.NotFound, 503: ERRORS.Unavailable,
+        },
+      },
+    },
+    '/normas/{idNorma}/articulos/{slug}': {
+      get: {
+        tags: ['normas'],
+        summary: 'One article body',
+        operationId: 'getArticulo',
+        parameters: [
+          IDNORMA_PARAM,
+          { name: 'slug', in: 'path', required: true, schema: { type: 'string' },
+            description: 'Article slug from the index.', example: 'art-1' },
+          FECHA_PARAM,
+        ],
+        responses: {
+          200: {
+            description:
+              'The article. Bodies are capped at 12,000 characters; when `truncado` is true the ' +
+              'text is incomplete and `largoCompleto` is the real length.',
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/Articulo' } } },
+            headers: { ETag: { schema: { type: 'string' } } },
+          },
+          304: { description: 'Not modified.' },
+          400: ERRORS.BadRequest, 401: ERRORS.Unauthorized, 404: ERRORS.NotFound, 503: ERRORS.Unavailable,
+        },
+      },
+    },
+    '/normas/{idNorma}/versiones': {
+      get: {
+        tags: ['normas'],
+        summary: 'Version history',
+        description:
+          'Every version with the window it was in force. `desde` values are the dates to pass ' +
+          'as `fecha`, `from` and `to` elsewhere.',
+        operationId: 'listVersiones',
+        parameters: [IDNORMA_PARAM],
+        responses: {
+          200: {
+            description: 'Versions, oldest first.',
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/VersionList' } } },
+            headers: { ETag: { schema: { type: 'string' } } },
+          },
+          304: { description: 'Not modified.' },
+          400: ERRORS.BadRequest, 401: ERRORS.Unauthorized, 404: ERRORS.NotFound, 503: ERRORS.Unavailable,
+        },
+      },
+    },
+    '/normas/{idNorma}/diff': {
+      get: {
+        tags: ['normas'],
+        summary: 'What changed between two versions',
+        description:
+          'The question the corpus exists to answer. Returns structured per-article insert and ' +
+          'delete operations. A norma that did not change returns 200 with an empty `cambios` ' +
+          'array — that is an answer, not an error.',
+        operationId: 'diffVersiones',
+        parameters: [
+          IDNORMA_PARAM,
+          { name: 'from', in: 'query', required: true, schema: { type: 'string', format: 'date' },
+            description: 'The earlier version date.', example: '2015-05-05' },
+          { name: 'to', in: 'query', required: true, schema: { type: 'string', format: 'date' },
+            description: 'The later version date.', example: '2016-04-15' },
+        ],
+        responses: {
+          200: {
+            description: 'The change set.',
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/Diff' } } },
+            headers: { ETag: { schema: { type: 'string' } } },
+          },
+          304: { description: 'Not modified.' },
+          400: errorResponse('Missing or malformed `from` / `to`.'),
+          401: ERRORS.Unauthorized,
+          404: errorResponse('No such norma, or no text at either date.'),
+          503: ERRORS.Unavailable,
+        },
+      },
+    },
+    '/normas/{idNorma}/modificaciones': {
+      get: {
+        tags: ['normas'],
+        summary: 'The modification graph, both directions',
+        description:
+          'What modified this norma, and what it modified. Every entry carries `idNorma`, so a ' +
+          'caller never has to resolve an ambiguous citation.',
+        operationId: 'getModificaciones',
+        parameters: [IDNORMA_PARAM],
+        responses: {
+          200: {
+            description: 'Both directions.',
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/Modificaciones' } } },
+            headers: { ETag: { schema: { type: 'string' } } },
+          },
+          304: { description: 'Not modified.' },
+          400: ERRORS.BadRequest, 401: ERRORS.Unauthorized, 404: ERRORS.NotFound, 503: ERRORS.Unavailable,
+        },
+      },
+    },
+    '/normas/{idNorma}/raw': {
+      get: {
+        tags: ['normas'],
+        summary: 'Canonical links to the authoritative source',
+        description: 'Links back to leychile.cl, for citing or verifying a version.',
+        operationId: 'getRawLinks',
+        parameters: [IDNORMA_PARAM, FECHA_PARAM],
+        responses: {
+          200: {
+            description: 'Upstream links.',
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/RawLinks' } } },
+            headers: { ETag: { schema: { type: 'string' } } },
+          },
+          304: { description: 'Not modified.' },
+          400: ERRORS.BadRequest, 401: ERRORS.Unauthorized, 404: ERRORS.NotFound, 503: ERRORS.Unavailable,
+        },
+      },
+    },
+  },
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        description: 'A key issued by the operator: `Authorization: Bearer lc_live_…`',
+      },
+    },
+    responses: {
+      BadRequest: errorResponse('Malformed `idNorma` or date, or a missing required parameter. Dates must be real calendar dates — 2026-02-31 is a 400.'),
+      Unauthorized: errorResponse('Missing, malformed, unknown or revoked key.'),
+      NotFound: errorResponse('No such norma, article or version.'),
+      Unavailable: errorResponse('Temporarily unavailable. An empty result array never means this — that is always a 4xx or 5xx.'),
+    },
+    schemas: {
+      Error: {
+        type: 'object',
+        required: ['error'],
+        properties: {
+          error: {
+            type: 'object',
+            required: ['code', 'message'],
+            properties: {
+              code: {
+                type: 'string',
+                enum: ['bad_request', 'missing_api_key', 'invalid_api_key', 'not_found', 'service_unavailable'],
+              },
+              message: { type: 'string' },
+            },
+          },
+        },
+        example: { error: { code: 'invalid_api_key', message: 'The API key is unknown or has been revoked.' } },
+      },
+      NormaRef: {
+        type: 'object',
+        required: ['idNorma', 'tipo', 'numero', 'titulo'],
+        properties: {
+          idNorma: { type: 'integer', example: 29994 },
+          tipo: { type: 'string', example: 'ley' },
+          numero: { type: 'string', example: '18603' },
+          titulo: { type: 'string', example: 'LEY ORGANICA CONSTITUCIONAL DE LOS PARTIDOS POLITICOS' },
+          organismo: { type: 'string', example: 'MINISTERIO DEL INTERIOR' },
+        },
+      },
+      SearchResult: {
+        type: 'object',
+        required: ['query', 'asOf', 'total', 'resultados'],
+        properties: {
+          query: { type: 'string' },
+          asOf: { type: 'string', format: 'date' },
+          total: { type: 'integer' },
+          resultados: { type: 'array', items: { $ref: '#/components/schemas/NormaRef' } },
+        },
+      },
+      ArticuloIndexEntry: {
+        type: 'object',
+        required: ['slug', 'label', 'rawHeading'],
+        properties: {
+          slug: { type: 'string', example: 'art-1', description: 'Use this to fetch the body.' },
+          label: { type: 'string', example: 'articulo 1' },
+          rawHeading: { type: 'string', example: 'Artículo 1º' },
+          snippet: { type: 'string', description: 'Present only when `q` was given. Contains <b> around the hit.' },
+        },
+      },
+      Norma: {
+        type: 'object',
+        required: ['idNorma', 'tipo', 'numero', 'titulo', 'fecha', 'totalVersiones', 'articulos'],
+        properties: {
+          idNorma: { type: 'integer', example: 29994 },
+          tipo: { type: 'string', example: 'ley' },
+          numero: { type: 'string', example: '18603' },
+          titulo: { type: 'string' },
+          organismo: { type: 'string', example: 'MINISTERIO DEL INTERIOR' },
+          derogado: { type: 'boolean' },
+          fechaPublicacion: { type: ['string', 'null'], format: 'date', example: '1987-03-23' },
+          fecha: { type: 'string', format: 'date', description: 'The version described.', example: '2016-04-15' },
+          totalVersiones: { type: 'integer', example: 6 },
+          articulos: { type: 'array', items: { $ref: '#/components/schemas/ArticuloIndexEntry' } },
+        },
+      },
+      ArticuloList: {
+        type: 'object',
+        required: ['idNorma', 'fecha', 'total', 'articulos'],
+        properties: {
+          idNorma: { type: 'integer' },
+          fecha: { type: 'string', format: 'date' },
+          query: { type: 'string', description: 'Echoed only when `q` was given.' },
+          total: { type: 'integer' },
+          articulos: { type: 'array', items: { $ref: '#/components/schemas/ArticuloIndexEntry' } },
+        },
+      },
+      Articulo: {
+        type: 'object',
+        required: ['idNorma', 'fecha', 'slug', 'label', 'body', 'truncado', 'largoCompleto'],
+        properties: {
+          idNorma: { type: 'integer' },
+          fecha: { type: 'string', format: 'date' },
+          slug: { type: 'string', example: 'art-1' },
+          label: { type: 'string', example: 'articulo 1' },
+          rawHeading: { type: 'string', example: 'Artículo 1º' },
+          body: { type: 'string' },
+          truncado: { type: 'boolean', description: 'True when the body was cut at 12,000 characters.' },
+          largoCompleto: { type: 'integer', description: 'The real body length, in characters.' },
+        },
+      },
+      Version: {
+        type: 'object',
+        required: ['desde', 'hasta'],
+        properties: {
+          desde: { type: 'string', format: 'date', example: '1987-03-23' },
+          hasta: { type: ['string', 'null'], format: 'date', description: 'Null for the version in force.' },
+          causaId: { type: ['integer', 'null'], description: 'idNorma of the norma that caused this version.' },
+          subject: { type: 'string' },
+        },
+      },
+      VersionList: {
+        type: 'object',
+        required: ['idNorma', 'vigente', 'total', 'versiones'],
+        properties: {
+          idNorma: { type: 'integer' },
+          vigente: { type: 'string', format: 'date', description: 'The version currently in force.' },
+          total: { type: 'integer', example: 122 },
+          versiones: { type: 'array', items: { $ref: '#/components/schemas/Version' } },
+        },
+      },
+      DiffOp: {
+        type: 'object',
+        required: ['op', 'text'],
+        properties: {
+          op: { type: 'string', enum: ['insert', 'delete'] },
+          text: { type: 'string' },
+        },
+      },
+      Cambio: {
+        type: 'object',
+        required: ['slug', 'rawHeading', 'estado'],
+        properties: {
+          slug: { type: 'string' },
+          rawHeading: { type: 'string' },
+          estado: { type: 'string', enum: ['modificado', 'añadido', 'eliminado'] },
+          ops: {
+            type: 'array', items: { $ref: '#/components/schemas/DiffOp' },
+            description: 'Present when `estado` is `modificado`.',
+          },
+          body: { type: 'string', description: 'Present when `estado` is `añadido`.' },
+          truncado: { type: 'boolean' },
+        },
+      },
+      Diff: {
+        type: 'object',
+        required: ['idNorma', 'from', 'to', 'resumen', 'cambios'],
+        properties: {
+          idNorma: { type: 'integer' },
+          from: { type: 'string', format: 'date' },
+          to: { type: 'string', format: 'date' },
+          resumen: {
+            type: 'object',
+            properties: {
+              modificados: { type: 'integer' },
+              'añadidos': { type: 'integer' },
+              eliminados: { type: 'integer' },
+            },
+          },
+          cambios: { type: 'array', items: { $ref: '#/components/schemas/Cambio' } },
+        },
+      },
+      ModLink: {
+        type: 'object',
+        required: ['idNorma', 'tipo', 'numero', 'titulo', 'fecha'],
+        properties: {
+          idNorma: { type: 'integer', example: 1089164 },
+          tipo: { type: 'string' },
+          numero: { type: 'string' },
+          titulo: { type: 'string' },
+          fecha: { type: 'string', format: 'date' },
+        },
+      },
+      Modificaciones: {
+        type: 'object',
+        required: ['idNorma', 'modifica', 'modificadaPor'],
+        properties: {
+          idNorma: { type: 'integer' },
+          modifica: {
+            type: 'array', items: { $ref: '#/components/schemas/ModLink' },
+            description: 'Normas this one modified.',
+          },
+          modificadaPor: {
+            type: 'array', items: { $ref: '#/components/schemas/ModLink' },
+            description: 'Normas that modified this one.',
+          },
+        },
+      },
+      RawLinks: {
+        type: 'object',
+        required: ['idNorma', 'fecha', 'url', 'xml'],
+        properties: {
+          idNorma: { type: 'integer' },
+          fecha: { type: 'string', format: 'date' },
+          url: { type: 'string', format: 'uri' },
+          xml: { type: 'string', format: 'uri' },
+        },
+      },
+    },
+  },
+} as const
+
+export async function GET() {
+  return Response.json(spec, {
+    headers: {
+      // Public, unlike every other /v1 response: this is a schema, identical
+      // for everyone, and not behind a key.
+      'cache-control': 'public, max-age=3600',
+    },
+  })
+}

--- a/site/components/CopyBlock.tsx
+++ b/site/components/CopyBlock.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useState } from 'react'
+
+/**
+ * A code block you can lift straight into a terminal.
+ *
+ * The copy affordance is the whole point: docs that make you select-and-drag a
+ * multi-line curl invocation get pasted wrong. Follows MCPConnect's idiom —
+ * copy, then confirm in place with an instruction rather than a toast.
+ */
+export function CopyBlock({
+  code,
+  caption,
+  lang = 'bash',
+}: {
+  code: string
+  caption?: string
+  lang?: 'bash' | 'json' | 'http'
+}) {
+  const [copied, setCopied] = useState(false)
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(code)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1600)
+    } catch {
+      // Clipboard is unavailable over plain HTTP and in some embedded views.
+      // The code is selectable either way, so say nothing rather than lie.
+    }
+  }
+
+  return (
+    <figure className="rounded-lg border border-rule bg-paper-sunk overflow-hidden">
+      <div className="flex items-center justify-between gap-3 px-3.5 pt-2.5 pb-2 border-b border-rule/60">
+        <figcaption className="text-[10px] uppercase tracking-[0.18em] text-ink-faint">
+          {caption ?? (lang === 'json' ? 'Respuesta' : 'Petición')}
+        </figcaption>
+        <button
+          onClick={copy}
+          className="text-[10px] uppercase tracking-[0.14em] text-ink-faint hover:text-ink transition-colors"
+          aria-label="Copiar al portapapeles"
+        >
+          {copied ? 'copiado' : 'copiar'}
+        </button>
+      </div>
+      <pre className="overflow-x-auto px-3.5 py-3 text-[12.5px] leading-relaxed">
+        <code className="font-mono text-ink-soft whitespace-pre">{code}</code>
+      </pre>
+    </figure>
+  )
+}


### PR DESCRIPTION
`docs/api.md` was a repo file — a prospective consumer had to know to look in GitHub to find it, and there was nothing machine-readable at all. This closes both gaps.

## `/api` — a public docs page

Public deliberately: you have to read it *before* you have a key, so gating it behind one would be circular.

**Structure taken from Stripe's and Vercel's references** — sticky endpoint nav, method-and-path as the section heading, a real response body beside every endpoint rather than in an appendix, and **parameters as a definition list rather than a table**. That last one surprised me: Stripe's own reference does it that way, and it's right — a four-column table is unreadable at narrow widths.

**The look is this site's, not theirs.** Warm paper instead of dark code slabs, Fraunces headings, Lora prose, JetBrains Mono code, ruby method pills, `paper-sunk` code blocks with rule borders. A docs page in a foreign visual language reads as bolted on. Only `CopyBlock` is a client component, so the page stays server-rendered.

## `/api/v1/openapi.json` — OpenAPI 3.1

Eight paths, fifteen schemas, `bearerAuth`, ETag/304 documented per endpoint. Public with a 1-hour cache, unlike every other `/v1` response, because a schema is not corpus data.

**Hand-written rather than generated.** The route handlers are plain functions with no schema decorators to derive from, so generating it would mean adding a validation layer purely to feed a document — and a wrong-but-generated schema is worse than an accurate hand-written one. The trade is that it must be updated alongside any endpoint change; that's noted in the file, and its eight paths mirror `KNOWN_ENDPOINTS`, which a test already pins.

## Verified

- `next build` registers both `/api` and `/api/v1/openapi.json` with **no conflict** against the `/api/[transport]` sibling (checked in `app-path-routes-manifest.json`).
- The standalone server returns `200` for `/api` with every expected section present.
- The spec parses as 8 paths / 15 schemas.
- **Every utility class used resolves in the compiled CSS** — so nothing renders silently unstyled.

## Not verified

**How it actually looks.** Chrome would not launch in this sandbox — I tried Chrome's own `--screenshot`, Playwright's bundled browser, and Playwright against the system Chrome. The page has never been rendered to a screen. Content, structure, build and CSS resolution are all confirmed; visual review is outstanding and worth a look before this is shared with anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5a463XjtoDsYpMC7Vzhi6