### PR TITLE
fix(landing): the year drill-down returned 400 of up to 12,766 events

### DIFF
--- a/site/app/api/idx/by-year/[year]/route.ts
+++ b/site/app/api/idx/by-year/[year]/route.ts
@@ -1,20 +1,43 @@
 import { pool } from '@/lib/db'
 
 /** Publication events for one year — mirrors idx/by-year/{year}.json. Powers the
- *  landing's year-filter drill-down (YearRibbon click). */
+ *  landing's year-filter drill-down (YearRibbon click).
+ *
+ *  Returns EVERY event in the year. This used to carry `LIMIT 400` under a
+ *  comment claiming it fetched "the full shard for that year", which it did
+ *  not: 64 of the corpus's 189 populated years exceed 400 events, so a third of
+ *  the ribbon's bars drilled down into a silently truncated list. Clicking 2022
+ *  showed 400 of 12,766. Worse, the truncation was invisible — the UI had no
+ *  way to say "there are more", so the density graph and its own drill-down
+ *  disagreed with each other.
+ *
+ *  Unbounded is affordable here: the worst year measures 47 ms and ~3.3 MB of
+ *  JSON before gzip, over a `version` table of ~344k rows that grows by a few
+ *  thousand a year. If that ever stops being true, the fix is pagination with a
+ *  total count — not a silent cap.
+ *
+ *  The year is matched as a half-open date range rather than
+ *  `extract(year FROM desde)`, which is index-eligible if an index on
+ *  `version.desde` is ever added. Identical semantics, no numeric cast. */
 export async function GET(_req: Request, ctx: { params: Promise<{ year: string }> }) {
   const { year } = await ctx.params
+
+  // Strict: `Number.isFinite` alone accepted "2022.5" and "1e9", which then
+  // reached make_date() as garbage.
+  if (!/^\d{4}$/.test(year)) return Response.json([])
   const y = Number(year)
-  if (!Number.isFinite(y)) return Response.json([])
+  if (y < 1800 || y > 2100) return Response.json([])
 
   const { rows } = await pool.query(
     `SELECT v.desde, v.causa_id, v.subject, n.id_norma, n.numero, n.tipo, n.titulo, n.organismo
        FROM version v JOIN norma n ON n.id_norma = v.id_norma
-      WHERE extract(year FROM v.desde) = $1 AND n.titulo <> ''
-      ORDER BY v.desde DESC
-      LIMIT 400`,
+      WHERE v.desde >= make_date($1, 1, 1)
+        AND v.desde <  make_date($1 + 1, 1, 1)
+        AND n.titulo <> ''
+      ORDER BY v.desde DESC`,
     [y],
   )
+
   return Response.json(
     rows.map((r) => ({
       sha: r.desde,
@@ -27,5 +50,11 @@ export async function GET(_req: Request, ctx: { params: Promise<{ year: string }
       titulo: r.titulo ?? '',
       organismo: r.organismo ?? '',
     })),
+    {
+      // A past year's events never change, and even the current year changes
+      // only when the loader runs. Worth caching now that the payload is the
+      // real thing rather than a 400-row slice.
+      headers: { 'cache-control': 'public, max-age=300, s-maxage=3600' },
+    },
   )
 }


### PR DESCRIPTION
## The bug

`/api/idx/by-year/{year}` carried `LIMIT 400`, under a comment claiming it fetched *"the full shard for that year"*. It didn't.

Measured against production: **64 of the corpus's 189 populated years exceed 400 events.** So a third of the density ribbon's bars drilled down into a silently truncated list. Clicking 2022 showed **400 of 12,766**.

The truncation was invisible — no total, no "more" affordance — so the graph and its own drill-down disagreed with each other. A bar sized by 12,766 publications opened a list of 400.

## The fix

Returns every event in the year. Unbounded is affordable, measured rather than assumed:

| | |
|---|---|
| worst year (2022) | 12,766 rows |
| query time, no limit | **47 ms** |
| payload before gzip | ~3.3 MB |
| `version` table | ~344k rows, +few thousand/yr |

If that stops being true, the fix is pagination with a total count — not a silent cap.

Three smaller things in the same file:

- **Half-open date range** instead of `extract(year FROM desde)`. Identical semantics, no numeric cast, and index-eligible if an index on `version.desde` is ever added.
- **Strict year validation.** `Number.isFinite` alone accepted `"2022.5"` and `"1e9"`, which then reached the query as garbage.
- **`Cache-Control: public, max-age=300, s-maxage=3600`.** A past year's events never change; the current year's change only when the loader runs. Worth caching now the payload is real.

## What was already fine

**The histogram itself.** It groups all of `norma` with no limit, and the data is clean: 1813–2026, 189 distinct years, 329,323 dated / 3,703 null, no sentinel or out-of-range values. `YearRibbon` iterates the full range without slicing.

## And one thing I got wrong

I reported earlier that `/sitemap.xml` was soft-404ing. **It isn't** — it returns a proper `404`, and `robots.txt` declares all 33 sitemaps, so Google finds every shard. I'd seen an HTML error body and assumed the status without checking it.

I then tried adding a real sitemap index there anyway, on the grounds that some tools probe `/sitemap.xml` by convention. Next refuses: `Conflicting route and metadata at /sitemap.xml` — the path is reserved for the `app/sitemap.ts` metadata convention. Which is exactly what the existing comment in `robots.ts` says. The current design is correct and this PR leaves it alone.

## Verified

`tsc --noEmit` clean, 142 tests passing, `next build` compiles with `/api/idx/by-year/[year]` registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5a463XjtoDsYpMC7Vzhi6