### PR TITLE
feat(reader): "citar ▾" on every article, in eight formats

### DIFF
--- a/site/app/norma/[id]/[[...rest]]/page.tsx
+++ b/site/app/norma/[id]/[[...rest]]/page.tsx
@@ -134,6 +134,14 @@ export default async function Page({ params }: Props) {
         siblings={siblings}
         siblingTotal={total}
         versionBase={canonicalHref(norma)}
+        cite={{
+          tipo: norma.tipo,
+          numero: norma.numero,
+          titulo: cleanTitulo(norma.titulo),
+          organismo: norma.organismo,
+          fechaPublicacion: norma.fechaPublicacion,
+          fecha,
+        }}
         banner={<AvisoBanner avisos={avisos} refundido={refundido} />}
       />
     </>

--- a/site/components/ArticleSegment.tsx
+++ b/site/components/ArticleSegment.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link'
 import { annotations, type HighlightColor } from '@/lib/annotations'
 import { SelectionToolbar } from '@/components/SelectionToolbar'
 import { NotePopover } from '@/components/NotePopover'
+import { CiteButton } from '@/components/CiteButton'
+import { useCiteSource } from '@/lib/citeContext'
 
 type Status = 'unchanged' | 'modified' | 'added' | 'removed'
 
@@ -59,6 +61,7 @@ export function ArticleSegment({
   }, [])
 
   const ann = annotations.for(idNorma, slug)
+  const citeSource = useCiteSource()
 
   // Apply highlights as inline marks after each render.
   useEffect(() => {
@@ -144,13 +147,18 @@ export function ArticleSegment({
           >
             {heading}
           </h2>
-          <button
-            onClick={onPermalink}
-            title="Copiar enlace permanente"
-            className="opacity-0 group-hover/header:opacity-100 transition text-[10px] text-ink-faint hover:text-indigo px-1.5 py-0.5 border border-rule rounded font-mono"
-          >
-            #
-          </button>
+          <span className="opacity-0 group-hover/header:opacity-100 focus-within:opacity-100 transition inline-flex items-center gap-1.5">
+            <button
+              onClick={onPermalink}
+              title="Copiar enlace permanente"
+              className="text-[10px] text-ink-faint hover:text-indigo px-1.5 py-0.5 border border-rule rounded font-mono"
+            >
+              #
+            </button>
+            {citeSource && (
+              <CiteButton source={{ ...citeSource, articulo: heading }} slug={slug} />
+            )}
+          </span>
           {causaId && causaId !== idNorma && (
             <Link
               href={`/ley/${causaId}`}

--- a/site/components/CiteButton.tsx
+++ b/site/components/CiteButton.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+import { CITE_FORMATS, renderCite, type CiteFormat, type CiteSource } from '@/lib/cite'
+
+/**
+ * "citar ▾" — copies a citation for this article in the reader's format.
+ *
+ * Sits beside the existing `#` permalink and shares its hover-reveal, so the
+ * article header gains an affordance without gaining visual noise.
+ *
+ * Clicking the label copies the Chilean legal form directly: it is the one
+ * that is unambiguously correct, and the common case should cost one click.
+ * The caret opens the rest — APA/MLA/Chicago for students, BibTeX/RIS for
+ * reference managers, Markdown for anyone linking to us.
+ */
+export function CiteButton({
+  source,
+  slug,
+}: {
+  /** Everything except the URL, which is resolved at click time. */
+  source: Omit<CiteSource, 'url'>
+  /** Article anchor on the page, e.g. "art-12". */
+  slug: string
+}) {
+  const [open, setOpen] = useState(false)
+  const [copied, setCopied] = useState<CiteFormat | null>(null)
+  const ref = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('mousedown', onDown)
+    window.addEventListener('keydown', onKey)
+    return () => {
+      window.removeEventListener('mousedown', onDown)
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  async function copy(fmt: CiteFormat) {
+    // Resolved at click time, not render time: the reader changes the version
+    // in the address bar without remounting, so a URL captured at render would
+    // cite the wrong date — the exact error this feature exists to prevent.
+    const { origin, pathname } = window.location
+    const url = `${origin}${pathname}#art-${slug}`
+    try {
+      await navigator.clipboard.writeText(renderCite(fmt, { ...source, url }))
+      setCopied(fmt)
+      setTimeout(() => setCopied(null), 1600)
+    } catch {
+      // Clipboard is unavailable over plain HTTP and in some embedded views.
+      // Saying nothing beats claiming a copy that did not happen.
+    }
+    setOpen(false)
+  }
+
+  const btn =
+    'text-[10px] text-ink-faint hover:text-indigo px-1.5 py-0.5 border border-rule ' +
+    'rounded transition'
+
+  return (
+    <div ref={ref} className="relative inline-flex items-stretch">
+      <button
+        onClick={() => copy('chile')}
+        title="Copiar cita legal"
+        className={`${btn} rounded-r-none border-r-0 font-ui`}
+      >
+        {copied ? 'copiado' : 'citar'}
+      </button>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Elegir formato de cita"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className={`${btn} rounded-l-none px-1 font-mono leading-none`}
+      >
+        ▾
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-1 z-30 w-48 rounded-lg border border-rule
+                     bg-paper-raised shadow-lg overflow-hidden"
+        >
+          {CITE_FORMATS.map((f) => (
+            <button
+              key={f.id}
+              role="menuitem"
+              onClick={() => copy(f.id)}
+              className="w-full text-left px-3 py-1.5 text-[12px] font-ui text-ink-soft
+                         hover:bg-paper-sunk hover:text-ink transition flex items-baseline gap-2"
+            >
+              <span>{f.label}</span>
+              {f.hint && (
+                <span className="ml-auto text-[10px] text-ink-faint">{f.hint}</span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/site/components/LawView.tsx
+++ b/site/components/LawView.tsx
@@ -14,6 +14,8 @@ import { ds } from '@/lib/datasource'
 import { tabs } from '@/lib/tabs'
 import { normaHref } from '@/lib/href'
 import type { Sibling } from '@/lib/norma'
+import { CiteProvider, type CiteContextValue } from '@/lib/citeContext'
+import { renderCite } from '@/lib/cite'
 
 /** Faithful port of web/'s ley.$numero.$fecha route. `fecha` optional: when
  *  absent (the undated URL) the latest version is shown. */
@@ -21,12 +23,14 @@ import type { Sibling } from '@/lib/norma'
  *  numero/id_norma collision that a client-side numero lookup hits at full
  *  corpus scale (an internal id_norma can equal an unrelated law's numero). */
 export function LawView({
-  tipo, numero, idNorma, fecha, siblings = [], siblingTotal = 1, versionBase, banner,
+  tipo, numero, idNorma, fecha, siblings = [], siblingTotal = 1, versionBase, banner, cite,
 }: {
   tipo: string
   numero: string
   idNorma: number
   fecha?: string
+  /** Norma identity for the per-article citation button. */
+  cite?: CiteContextValue
   /** Server-rendered warnings (refundido, numbering observations). Passed as a
    *  node rather than data so the metadata query stays on the server. */
   banner?: React.ReactNode
@@ -105,15 +109,19 @@ export function LawView({
   const onToggleCollapse = () => setPrefs(writePrefs({ collapseUnchanged: !prefs.collapseUnchanged }))
 
   const onCopyCitation = async () => {
-    const cite = formatCitation({
+    // Same renderer as the per-article button: one citation implementation,
+    // so the norma-level and article-level forms cannot drift apart.
+    const text = renderCite('chile', {
       tipo: idx.norma.tipo,
       numero: idx.norma.numero,
       titulo: idx.norma.titulo,
-      versionDate: active?.date ?? '',
-      url: active ? ds.textUrl(idx.relDir, active.sha) : '',
+      organismo: cite?.organismo,
+      fechaPublicacion: cite?.fechaPublicacion ?? null,
+      fecha: active?.date,
+      url: `${window.location.origin}${window.location.pathname}`,
     })
     try {
-      await navigator.clipboard.writeText(cite)
+      await navigator.clipboard.writeText(text)
       setCitationCopied(true)
       window.setTimeout(() => setCitationCopied(false), 1800)
     } catch {
@@ -227,14 +235,19 @@ export function LawView({
   )
 
   return (
-    <IDEShell
-      navigator={<Navigator activeId={idx.norma.idNorma} />}
-      center={center}
-      rightRail={<RightRail idx={idx} active={active} activeSlug={activeSlug} />}
-      // Efectos shows two panes side by side — let it fill the reading column
-      // instead of the single-column reading measure.
-      centerMaxWidth={effectiveMode === 'efectos' ? 'max-w-none' : 'max-w-3xl'}
-    />
+    // Norma identity is ambient to the whole reader, so the per-article citation
+    // button reads it from context instead of being prop-drilled through
+    // RedlineReader's three ArticleSegment call sites.
+    <CiteProvider value={cite ?? null}>
+      <IDEShell
+        navigator={<Navigator activeId={idx.norma.idNorma} />}
+        center={center}
+        rightRail={<RightRail idx={idx} active={active} activeSlug={activeSlug} />}
+        // Efectos shows two panes side by side — let it fill the reading column
+        // instead of the single-column reading measure.
+        centerMaxWidth={effectiveMode === 'efectos' ? 'max-w-none' : 'max-w-3xl'}
+      />
+    </CiteProvider>
   )
 }
 
@@ -273,19 +286,6 @@ function ModeToggle({
   )
 }
 
-function formatCitation({
-  tipo, numero, titulo, versionDate, url,
-}: { tipo: string; numero: string; titulo: string; versionDate: string; url: string }): string {
-  const head = `${capitalize(tipo)} N° ${numero}, "${truncate(titulo, 80)}"`
-  const date = versionDate ? `, versión vigente al ${versionDate}` : ''
-  return `${head}${date}.\nTexto: ${url}\nVía LeyChile`
-}
-function capitalize(s: string): string {
-  return s ? s[0].toUpperCase() + s.slice(1) : s
-}
-function truncate(s: string, n: number): string {
-  return s.length <= n ? s : s.slice(0, n - 1).trimEnd() + '…'
-}
 function Loading() {
   return <div className="opacity-60 mt-12 text-center text-sm">Cargando…</div>
 }

--- a/site/lib/cite.test.ts
+++ b/site/lib/cite.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+
+import { renderCite, normaName, prettyNumero, CITE_FORMATS, type CiteSource } from './cite'
+
+const LEY: CiteSource = {
+  tipo: 'ley',
+  numero: '21719',
+  titulo: 'REGULA LA PROTECCIÓN Y EL TRATAMIENTO DE LOS DATOS PERSONALES',
+  organismo: 'MINISTERIO DE ECONOMÍA',
+  fechaPublicacion: '2024-08-26',
+  fecha: '2024-08-26',
+  url: 'https://leyes.pisanvs.cl/norma/1205200/ley-21719/2024-08-26#art-12',
+  articulo: 'Artículo 12',
+}
+
+const FIXED_TODAY = new Date('2026-09-10T12:00:00Z')
+
+describe('prettyNumero', () => {
+  it('adds the thousands separator Chilean law numbers are written with', () => {
+    expect(prettyNumero('21719')).toBe('21.719')
+    expect(prettyNumero('1')).toBe('1')
+    // Not every numero is numeric — "S/N" covers 1,259 certificados alone.
+    expect(prettyNumero('S/N')).toBe('S/N')
+  })
+})
+
+describe('normaName', () => {
+  it('renders the kind Chilean legal writing uses', () => {
+    expect(normaName(LEY)).toBe('Ley N° 21.719')
+    expect(normaName({ ...LEY, tipo: 'dfl', numero: '1' })).toBe('Decreto con Fuerza de Ley N° 1')
+    expect(normaName({ ...LEY, tipo: 'dl', numero: '3500' })).toBe('Decreto Ley N° 3.500')
+  })
+
+  it('names códigos instead of numbering them', () => {
+    // "Código N° 1" is not a thing anyone writes; the code has a name.
+    expect(normaName({ ...LEY, tipo: 'cod', numero: '1', titulo: 'CÓDIGO PENAL' }))
+      .toBe('CÓDIGO PENAL')
+  })
+})
+
+describe('renderCite', () => {
+  it('chile: norm, article, gazette, date — the unambiguous default', () => {
+    expect(renderCite('chile', LEY, FIXED_TODAY))
+      .toBe('Ley N° 21.719, art. 12, Diario Oficial, 26 de agosto de 2024.')
+  })
+
+  it('markdown: link text names the article AND the version date', () => {
+    // A blogger's readers see the link text out of context, so it has to say
+    // which text it points at — that is the whole pitch against leychile.cl.
+    const md = renderCite('markdown', LEY, FIXED_TODAY)
+    expect(md).toBe(
+      '[Art. 12 de la Ley N° 21.719 (texto al 2024-08-26)]' +
+      '(https://leyes.pisanvs.cl/norma/1205200/ley-21719/2024-08-26#art-12)',
+    )
+  })
+
+  it('markdown: omits the version date when citing the current text', () => {
+    const md = renderCite('markdown', { ...LEY, fecha: undefined }, FIXED_TODAY)
+    expect(md).not.toContain('texto al')
+    expect(md).toContain('](https://leyes.pisanvs.cl/')
+  })
+
+  it('apa: year and date, gazette, URL', () => {
+    const s = renderCite('apa', LEY, FIXED_TODAY)
+    expect(s).toContain('Ley N° 21.719, art. 12.')
+    expect(s).toContain('(2024, 26 de agosto)')
+    expect(s).toContain('Diario Oficial de la República de Chile')
+    expect(s).toContain(LEY.url)
+  })
+
+  it('mla: quoted title, abbreviated month, bare host', () => {
+    const s = renderCite('mla', LEY, FIXED_TODAY)
+    expect(s).toContain('"Ley N° 21.719, art. 12."')
+    expect(s).toContain('26 ago. 2024')
+    // MLA drops the scheme.
+    expect(s).toContain('leyes.pisanvs.cl/')
+    expect(s).not.toContain('https://leyes')
+  })
+
+  it('bibtex: parses as one entry with a usable key and an access date', () => {
+    const s = renderCite('bibtex', LEY, FIXED_TODAY)
+    expect(s.startsWith('@legislation{ley21719,')).toBe(true)
+    expect(s.trimEnd().endsWith('}')).toBe(true)
+    expect(s).toContain('urldate      = {2026-09-10}')
+    // Braces must balance or the entry breaks a whole .bib file.
+    expect((s.match(/{/g) ?? []).length).toBe((s.match(/}/g) ?? []).length)
+  })
+
+  it('ris: correct statute type and a terminator, which importers require', () => {
+    const s = renderCite('ris', LEY, FIXED_TODAY)
+    expect(s.startsWith('TY  - STAT')).toBe(true)
+    expect(s.trimEnd().endsWith('ER  -')).toBe(true)
+    expect(s).toContain('DA  - 2024/08/26')
+    // Every line must be a RIS tag; a stray line makes importers reject the file.
+    for (const line of s.split('\n')) expect(line).toMatch(/^[A-Z][A-Z0-9]\s{2}- ?/)
+  })
+
+  it('url: exactly the URL, nothing decorating it', () => {
+    expect(renderCite('url', LEY, FIXED_TODAY)).toBe(LEY.url)
+  })
+
+  it('cites the whole norma when no article is given', () => {
+    const s = renderCite('chile', { ...LEY, articulo: undefined }, FIXED_TODAY)
+    expect(s).toBe('Ley N° 21.719, Diario Oficial, 26 de agosto de 2024.')
+    expect(s).not.toContain('art.')
+  })
+
+  it('degrades to "s. f." rather than inventing a date', () => {
+    // 3,703 normas have no publication date. Fabricating one in a citation
+    // would be worse than admitting it is unknown.
+    const undated = { ...LEY, fechaPublicacion: null }
+    expect(renderCite('apa', undated, FIXED_TODAY)).toContain('s. f.')
+    expect(renderCite('mla', undated, FIXED_TODAY)).toContain('s. f.')
+    expect(renderCite('chile', undated, FIXED_TODAY)).not.toContain('undefined')
+  })
+
+  it('never emits "undefined" or "null" in any format', () => {
+    const sparse: CiteSource = {
+      tipo: 'res', numero: 'S/N', titulo: '', url: 'https://x/y',
+      fechaPublicacion: null,
+    }
+    for (const { id } of CITE_FORMATS) {
+      const out = renderCite(id, sparse, FIXED_TODAY)
+      expect(out, id).not.toMatch(/undefined|null|NaN/)
+      expect(out.length, id).toBeGreaterThan(0)
+    }
+  })
+
+  it('does not shift the date across a timezone boundary', () => {
+    // lib/db.ts already guards this for DATE columns; the same trap applies to
+    // any Date built from a bare YYYY-MM-DD in a positive-offset zone.
+    expect(renderCite('chile', { ...LEY, fechaPublicacion: '2024-01-01' }, FIXED_TODAY))
+      .toContain('1 de enero de 2024')
+  })
+})

--- a/site/lib/cite.ts
+++ b/site/lib/cite.ts
@@ -1,0 +1,172 @@
+/**
+ * Citation rendering for a Chilean norma, or one article of it.
+ *
+ * A caveat that belongs in the code, not just a PR description: citing Chilean
+ * legislation in APA and MLA is genuinely under-specified. Both standards defer
+ * to local legal convention for non-US statutes, and Chilean faculties often
+ * carry house rules. The renderings below are defensible readings of each
+ * standard applied to Chilean norms — they are not authoritative, and a student
+ * whose professor demands something else should be able to see that at a
+ * glance. That is why `chile` is the default: it is the form Chilean legal
+ * writing actually uses, and it is unambiguous.
+ *
+ * `markdown` exists for a different audience entirely. A legal blogger wants a
+ * link they can paste, and that is the format that earns inbound links.
+ */
+
+export type CiteFormat =
+  | 'chile' | 'apa' | 'mla' | 'chicago' | 'bibtex' | 'ris' | 'markdown' | 'url'
+
+export interface CiteSource {
+  tipo: string
+  numero: string
+  titulo: string
+  organismo?: string
+  /** The version being read, YYYY-MM-DD. Absent means the current text. */
+  fecha?: string
+  /** Publication date, YYYY-MM-DD. */
+  fechaPublicacion?: string | null
+  url: string
+  /** Article label as displayed, e.g. "Artículo 12". Absent cites the norma. */
+  articulo?: string
+}
+
+const MESES = [
+  'enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio',
+  'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre',
+]
+const MESES_ABBR = [
+  'ene.', 'feb.', 'mar.', 'abr.', 'may.', 'jun.',
+  'jul.', 'ago.', 'sept.', 'oct.', 'nov.', 'dic.',
+]
+
+/** Spanish thousands separators: Chilean law numbers are written "21.719". */
+export function prettyNumero(n: string): string {
+  return /^\d{4,}$/.test(n) ? Number(n).toLocaleString('es-CL') : n
+}
+
+/** "26 de agosto de 2024" — parsed as UTC so the date never shifts a day in a
+ *  positive-offset timezone, the same trap lib/db.ts guards for DATE columns. */
+function longDate(iso?: string | null): string | null {
+  if (!iso || !/^\d{4}-\d{2}-\d{2}$/.test(iso)) return null
+  const [y, m, d] = iso.split('-').map(Number)
+  return `${d} de ${MESES[m - 1]} de ${y}`
+}
+
+function shortDate(iso?: string | null): string | null {
+  if (!iso || !/^\d{4}-\d{2}-\d{2}$/.test(iso)) return null
+  const [y, m, d] = iso.split('-').map(Number)
+  return `${d} ${MESES_ABBR[m - 1]} ${y}`
+}
+
+function yearOf(iso?: string | null): string | null {
+  return iso && /^\d{4}/.test(iso) ? iso.slice(0, 4) : null
+}
+
+/** "Ley N° 21.719" — the norma's name as Chilean legal writing renders it. */
+export function normaName(s: CiteSource): string {
+  const label: Record<string, string> = {
+    ley: 'Ley', dl: 'Decreto Ley', dfl: 'Decreto con Fuerza de Ley',
+    dto: 'Decreto', cod: 'Código', res: 'Resolución',
+  }
+  const kind = label[s.tipo] ?? s.tipo.toUpperCase()
+  // Códigos are named, not numbered: "Código Penal", never "Código N° 1".
+  if (s.tipo === 'cod') return s.titulo.trim() || `${kind} ${s.numero}`
+  return `${kind} N° ${prettyNumero(s.numero)}`
+}
+
+/** "art. 12" from "Artículo 12" — citation styles abbreviate. */
+function artShort(articulo?: string): string | null {
+  if (!articulo) return null
+  const n = articulo.replace(/^[Aa]rt[íi]culo\s*/, '').trim()
+  return n ? `art. ${n}` : null
+}
+
+const DO = 'Diario Oficial de la República de Chile'
+
+export function renderCite(fmt: CiteFormat, s: CiteSource, today = new Date()): string {
+  const name = normaName(s)
+  const art = artShort(s.articulo)
+  const pub = longDate(s.fechaPublicacion)
+  const year = yearOf(s.fechaPublicacion)
+  const accessed = today.toISOString().slice(0, 10)
+
+  switch (fmt) {
+    case 'url':
+      return s.url
+
+    case 'markdown':
+      // What a blogger pastes. The visible text carries the article and the
+      // version date, so the link says what it points at even out of context.
+      return `[${art ? `${art.replace('art.', 'Art.')} de la ${name}` : name}${
+        s.fecha ? ` (texto al ${s.fecha})` : ''
+      }](${s.url})`
+
+    case 'chile':
+      // How Chilean legal writing cites: norm, article, official gazette, date.
+      return [
+        name,
+        art,
+        pub ? `${DO.replace(' de la República de Chile', '')}, ${pub}` : null,
+      ].filter(Boolean).join(', ') + '.'
+
+    case 'apa':
+      // APA 7 defers to local convention for non-US statutes; this follows its
+      // reference shape — title, date, source, URL.
+      return `${name}${art ? `, ${art}` : ''}. (${
+        pub ? `${year}, ${pub.replace(` de ${year}`, '')}` : 's. f.'
+      }). ${DO}. ${s.url}`
+
+    case 'mla':
+      return `"${name}${art ? `, ${art}` : ''}." ${DO}, ${
+        shortDate(s.fechaPublicacion) ?? 's. f.'
+      }, ${s.url.replace(/^https?:\/\//, '')}.`
+
+    case 'chicago':
+      // Notes-bibliography, the style Chilean legal scholarship tends to use.
+      return `${name}${art ? `, ${art}` : ''}, ${DO.replace(' de la República de Chile', '')}, ${
+        pub ?? 's. f.'
+      }, ${s.url}.`
+
+    case 'bibtex': {
+      const key = `${s.tipo}${s.numero}`.replace(/[^a-zA-Z0-9]/g, '')
+      return [
+        `@legislation{${key},`,
+        `  title        = {${name}${art ? `, ${art}` : ''}},`,
+        s.titulo ? `  subtitle     = {${s.titulo}},` : null,
+        `  journal      = {${DO}},`,
+        year ? `  year         = {${year}},` : null,
+        s.organismo ? `  institution  = {${s.organismo}},` : null,
+        `  url          = {${s.url}},`,
+        `  urldate      = {${accessed}},`,
+        '}',
+      ].filter(Boolean).join('\n')
+    }
+
+    case 'ris':
+      // TY - STAT is the RIS type for a statute; Zotero and Mendeley both map it.
+      return [
+        'TY  - STAT',
+        `TI  - ${name}${art ? `, ${art}` : ''}`,
+        s.titulo ? `T2  - ${s.titulo}` : null,
+        `JO  - ${DO}`,
+        s.fechaPublicacion ? `DA  - ${s.fechaPublicacion.replace(/-/g, '/')}` : null,
+        year ? `PY  - ${year}` : null,
+        s.organismo ? `PB  - ${s.organismo}` : null,
+        `UR  - ${s.url}`,
+        `Y2  - ${accessed.replace(/-/g, '/')}`,
+        'ER  - ',
+      ].filter(Boolean).join('\n')
+  }
+}
+
+export const CITE_FORMATS: { id: CiteFormat; label: string; hint?: string }[] = [
+  { id: 'chile', label: 'Cita legal', hint: 'uso chileno' },
+  { id: 'apa', label: 'APA 7' },
+  { id: 'mla', label: 'MLA 9' },
+  { id: 'chicago', label: 'Chicago' },
+  { id: 'bibtex', label: 'BibTeX', hint: 'Zotero, LaTeX' },
+  { id: 'ris', label: 'RIS', hint: 'Mendeley, EndNote' },
+  { id: 'markdown', label: 'Markdown', hint: 'para enlazar' },
+  { id: 'url', label: 'Enlace' },
+]

--- a/site/lib/citeContext.tsx
+++ b/site/lib/citeContext.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+
+import type { CiteSource } from '@/lib/cite'
+
+/**
+ * Norma identity for the citation button, provided once per reader.
+ *
+ * `ArticleSegment` receives only `idNorma`, `slug`, `heading`, `status` and
+ * `causaId` — nothing a citation needs. `RedlineReader` renders it in three
+ * places, so threading tipo/numero/titulo/fecha as props would mean touching
+ * every one of them and every caller above.
+ *
+ * A context is the smaller change and the more honest boundary: the norma's
+ * identity is ambient to the whole reader, not a property of one segment.
+ *
+ * Null when absent, so a segment rendered outside a reader (a test, a future
+ * embed) simply omits the button rather than crashing.
+ */
+export type CiteContextValue = Omit<CiteSource, 'url' | 'articulo'> | null
+
+const Ctx = createContext<CiteContextValue>(null)
+
+export function CiteProvider({
+  value,
+  children,
+}: {
+  value: CiteContextValue
+  children: React.ReactNode
+}) {
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>
+}
+
+export function useCiteSource(): CiteContextValue {
+  return useContext(Ctx)
+}


### PR DESCRIPTION
A law student who can cite an article in one click has a reason to come back. A blogger who can copy a Markdown link has a reason to link to us. Same button, different output.

Sits beside the existing `#` permalink and shares its hover-reveal. Clicking the label copies the **Chilean legal form** — the one that's unambiguously correct — so the common case costs one click. The caret opens the rest.

| format | for |
|---|---|
| **Cita legal** (default) | Chilean legal writing |
| APA 7 · MLA 9 · Chicago | students |
| **BibTeX · RIS** | Zotero, Mendeley, EndNote |
| **Markdown** | bloggers — the format that earns links |
| Enlace | everyone |

BibTeX and RIS are the deeper hook: a postgrad imports into Zotero once and the corpus is in their library for the rest of the thesis.

Markdown's link text names **both the article and the version date**, so the citation reads correctly out of context. That's the entire pitch against linking to leychile.cl, where a post about a 2020 reform links to a page showing today's text:

```
[Art. 12 de la Ley N° 21.719 (texto al 2024-08-26)](https://leyes.pisanvs.cl/...)
```

## Unifies the citation renderer

`LawView` already had a private `formatCitation` producing an ad-hoc format (`"…", versión vigente al …` / `Vía LeyChile`) for the whole-norma button. Shipping a second renderer beside it is how two formats drift, so both now call `lib/cite`. The norma-level button's output therefore **changes** to the Chilean legal form — deliberate, not a side effect.

## Two design notes

**Context, not props.** `ArticleSegment` gets only `idNorma/slug/heading/status/causaId`, and `RedlineReader` renders it in three places. Norma identity is ambient to the reader, so a context is both the smaller change and the more honest boundary. Null outside a reader → the button just doesn't render.

**URL resolved at click time, not render.** The reader changes the version in the address bar without remounting, so a URL captured at render would cite the wrong date — precisely the error this feature exists to prevent.

## Caveat, also in the source

**Citing Chilean legislation in APA and MLA is genuinely under-specified.** Both defer to local convention for non-US statutes, and Chilean faculties carry house rules. These are defensible readings, not authoritative ones.

I'd have a law student check the output against their faculty's guide before promoting this. The Chilean legal form is the default precisely because it's the one form not in doubt.

## Tests

15, pinning what rots silently: BibTeX braces balance (a stray one breaks a whole `.bib`), every RIS line is a valid tag and the entry terminates (importers reject otherwise), dates don't shift a day across a timezone, no format ever emits `undefined`, and an undated norma degrades to `s. f.` rather than inventing a date — **3,703 normas have no publication date**.

166 tests passing, `tsc --noEmit` clean, `next build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5a463XjtoDsYpMC7Vzhi6