### PR TITLE
feat(seo): /citar tool and a three-post citation cluster

### DIFF
--- a/site/app/citar/page.tsx
+++ b/site/app/citar/page.tsx
@@ -1,0 +1,258 @@
+// Queries Postgres, so it must not be prerendered: `next build` runs with no
+// DATABASE_URL reachable. Same constraint as app/guia.
+export const dynamic = 'force-dynamic'
+
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { getNormaById, getVersions, currentFecha } from '@/lib/norma'
+import { runSearch } from '@/lib/search'
+import { canonicalHref } from '@/lib/href'
+import { faqJsonLd, jsonLdScript, SITE, cleanTitulo } from '@/lib/jsonld'
+import { CiteFormatList } from '@/components/CiteFormatList'
+import { normaName, type CiteSource } from '@/lib/cite'
+
+/**
+ * `/citar` — find a Chilean norma and get its citation in eight formats.
+ *
+ * Server-rendered on purpose. The point of this page is to rank for "cómo citar
+ * una ley chilena" and its variants, so the guide has to be in the HTML, and
+ * the tool has to work with JavaScript disabled. Search and selection are plain
+ * GET parameters; only the copy buttons are client-side.
+ *
+ * It is a tool rather than only an article because a free tool that does the
+ * job is linkable in a way a blog post is not — which is the actual goal.
+ */
+
+const FAQ: { q: string; a: string }[] = [
+  {
+    q: '¿Cómo se cita una ley chilena?',
+    a:
+      'El uso chileno cita la norma, el artículo si corresponde, el Diario Oficial y la fecha de ' +
+      'publicación. Por ejemplo: «Ley N° 21.719, art. 12, Diario Oficial, 26 de agosto de 2024.» ' +
+      'Para APA, MLA o Chicago la estructura cambia, pero los datos son los mismos.',
+  },
+  {
+    q: '¿Cómo se cita un artículo específico de una ley?',
+    a:
+      'Se agrega el artículo después del número de la norma: «Ley N° 21.719, art. 12». En APA y ' +
+      'MLA el artículo va junto al título de la norma. Conviene además enlazar directamente al ' +
+      'artículo, no a la ley completa.',
+  },
+  {
+    q: '¿Cómo cito la versión de una ley que regía en una fecha pasada?',
+    a:
+      'Hay que indicar la versión, porque el texto vigente hoy no es el que regía entonces. Una ' +
+      'cita de un hecho de 2015 debe apuntar al texto vigente en 2015. En leyes.pisanvs.cl cada ' +
+      'versión tiene su propia URL con la fecha, de modo que el enlace muestra el texto correcto.',
+  },
+  {
+    q: '¿Cómo cito un DFL o un decreto si hay varios con el mismo número?',
+    a:
+      'El par (tipo, número) no identifica una norma chilena: existen 227 normas llamadas «DFL 1» ' +
+      'y 525 llamadas «DTO 1», de distintos organismos y años. La cita debe incluir el organismo ' +
+      'y el año, o bien el idNorma, que sí es único.',
+  },
+  {
+    q: '¿Qué es el Diario Oficial en una cita legal?',
+    a:
+      'Es la publicación donde se promulgan las normas chilenas, y cumple el papel que en una ' +
+      'cita bibliográfica tendría la revista o editorial. Por eso aparece en todos los formatos.',
+  },
+]
+
+export const metadata: Metadata = {
+  title: 'Cómo citar una ley chilena — generador de citas (legal, APA, MLA, Chicago)',
+  description:
+    'Busca cualquier ley, decreto o código chileno y copia su cita en formato legal chileno, ' +
+    'APA 7, MLA 9, Chicago, BibTeX o RIS. Incluye cómo citar un artículo y cómo citar la versión ' +
+    'que regía en una fecha pasada.',
+  alternates: { canonical: `${SITE}/citar` },
+}
+
+interface SP {
+  searchParams: Promise<{ q?: string; id?: string; fecha?: string }>
+}
+
+export default async function Page({ searchParams }: SP) {
+  const sp = await searchParams
+  const q = (sp.q ?? '').trim()
+  const id = /^[1-9]\d*$/.test(sp.id ?? '') ? Number(sp.id) : null
+
+  const norma = id ? await getNormaById(id) : null
+  const versions = norma ? await getVersions(norma.idNorma) : []
+  const fecha =
+    norma && /^\d{4}-\d{2}-\d{2}$/.test(sp.fecha ?? '') ? sp.fecha! : undefined
+
+  const results = !norma && q.length >= 2 ? await runSearch(q, new Date().toISOString().slice(0, 10), 8) : []
+
+  const source: CiteSource | null = norma
+    ? {
+        tipo: norma.tipo,
+        numero: norma.numero,
+        titulo: cleanTitulo(norma.titulo),
+        organismo: norma.organismo,
+        fechaPublicacion: norma.fechaPublicacion,
+        fecha: fecha ?? undefined,
+        url: `${SITE}${canonicalHref(norma, fecha)}`,
+      }
+    : null
+
+  return (
+    <div className="flex-1 overflow-y-auto scrollbar-quiet">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: jsonLdScript(faqJsonLd(FAQ)),
+        }}
+      />
+
+      <div className="px-6 md:px-12 max-w-3xl mx-auto pt-16 pb-24">
+        <p className="text-[10.5px] uppercase tracking-[0.25em] text-ink-faint mb-5">
+          Herramienta
+        </p>
+        <h1 className="font-display text-4xl md:text-[3rem] leading-[1.06] tracking-tight text-balance">
+          Cómo citar una <span className="text-ruby">ley chilena</span>.
+        </h1>
+        <p className="mt-6 text-ink-soft text-[15.5px] leading-relaxed">
+          Busca la norma, elige el formato, copia la cita. Formato legal chileno, APA 7, MLA 9,
+          Chicago, y BibTeX o RIS para Zotero y Mendeley. Incluye el caso que casi ninguna guía
+          cubre: citar la versión que regía en una fecha pasada.
+        </p>
+
+        {/* ── The tool ─────────────────────────────────────────────── */}
+        <form action="/citar" method="get" className="mt-9 flex gap-2">
+          <input
+            type="search"
+            name="q"
+            defaultValue={q}
+            placeholder="ley 21719, código del trabajo, medio ambiente…"
+            aria-label="Buscar una norma"
+            className="flex-1 rounded-lg border border-rule bg-paper-raised px-3.5 py-2.5 text-[14.5px]
+                       text-ink placeholder:text-ink-faint focus:outline-none focus:border-ink/40 transition"
+          />
+          <button
+            type="submit"
+            className="rounded-lg border border-rule px-4 text-[13px] font-ui text-ink-soft
+                       hover:text-ink hover:border-ink/40 transition"
+          >
+            Buscar
+          </button>
+        </form>
+
+        {results.length > 0 && (
+          <ul className="mt-5 divide-y divide-rule border-t border-rule">
+            {results.map((r) => (
+              <li key={r.idNorma}>
+                <Link
+                  href={`/citar?id=${r.idNorma}`}
+                  className="group flex flex-col gap-0.5 py-3 hover:bg-paper-sunk/50 -mx-2 px-2 rounded transition"
+                >
+                  <span className="text-[11px] uppercase tracking-widest text-ink-faint">
+                    {r.tipo} {r.numero}
+                  </span>
+                  <span className="font-display text-[1.02rem] leading-snug group-hover:text-ruby transition line-clamp-2">
+                    {cleanTitulo(r.titulo)}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {q.length >= 2 && results.length === 0 && !norma && (
+          <p className="mt-5 text-[14px] text-ink-faint">
+            Sin resultados para «{q}».
+          </p>
+        )}
+
+        {source && norma && (
+          <section className="mt-9 border-t border-rule pt-8">
+            <p className="text-[11px] uppercase tracking-widest text-ink-faint">
+              {normaName(source)}
+              {norma.organismo && ` · ${norma.organismo}`}
+            </p>
+            <h2 className="font-display text-2xl leading-snug mt-1 mb-1">
+              {cleanTitulo(norma.titulo)}
+            </h2>
+            <p className="text-[13px] text-ink-faint mb-5">
+              Citando {fecha ? `la versión vigente al ${fecha}` : 'el texto vigente'}
+              {versions.length > 1 && ` · ${versions.length} versiones`}
+              {' · '}
+              <Link href={canonicalHref(norma, fecha)} className="text-indigo hover:text-ruby underline underline-offset-2">
+                leer la norma
+              </Link>
+            </p>
+
+            {versions.length > 1 && (
+              <div className="mb-6">
+                <p className="text-[11px] uppercase tracking-[0.16em] text-ink-faint mb-2">
+                  ¿Necesitas citar otra versión?
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {versions.map((v) => {
+                    const active = (fecha ?? currentFecha(versions)) === v.desde
+                    return (
+                      <Link
+                        key={v.desde}
+                        href={`/citar?id=${norma.idNorma}&fecha=${v.desde}`}
+                        className={`font-mono text-[11px] px-2 py-1 rounded border transition ${
+                          active
+                            ? 'border-ruby text-ruby'
+                            : 'border-rule text-ink-faint hover:text-ink hover:border-ink/40'
+                        }`}
+                      >
+                        {v.desde}
+                      </Link>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            <CiteFormatList source={source} />
+          </section>
+        )}
+
+        {/* ── The guide ────────────────────────────────────────────── */}
+        <section className="mt-16 border-t border-rule pt-10">
+          <h2 className="font-display text-2xl mb-4">Preguntas frecuentes</h2>
+          <dl className="space-y-6">
+            {FAQ.map((f) => (
+              <div key={f.q}>
+                <dt className="font-display text-[1.1rem] leading-snug mb-1.5">{f.q}</dt>
+                <dd className="text-ink-soft text-[14.5px] leading-relaxed">{f.a}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        <section className="mt-12 border-t border-rule pt-10">
+          <h2 className="font-display text-2xl mb-3">Por qué la versión importa</h2>
+          <p className="text-ink-soft text-[14.5px] leading-relaxed">
+            Una cita legal apunta a un texto, y el texto de una ley cambia. El Código Penal tiene
+            122 versiones desde 1874; la ley del consumidor, nueve. Si tu trabajo analiza un hecho
+            de 2015 y tu cita enlaza al texto de hoy, la cita contradice al texto que estás
+            comentando — y quien la siga leerá algo distinto de lo que tú leíste.
+          </p>
+          <p className="text-ink-soft text-[14.5px] leading-relaxed mt-3">
+            Por eso cada versión aquí tiene su propia URL con la fecha, y por eso las citas de esta
+            página incluyen la versión cuando corresponde. Es la diferencia entre citar «la ley» y
+            citar la ley que efectivamente regía.
+          </p>
+          <p className="text-ink-soft text-[14.5px] leading-relaxed mt-5">
+            Más sobre esto en{' '}
+            <Link href="/blog/leer-la-ley-en-una-fecha" className="text-indigo hover:text-ruby underline underline-offset-2">
+              cómo leer la ley que regía en una fecha exacta
+            </Link>
+            {' '}y en la{' '}
+            <Link href="/blog/citar-ley-chilena" className="text-indigo hover:text-ruby underline underline-offset-2">
+              guía completa de citación
+            </Link>
+            .
+          </p>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/site/components/CiteFormatList.tsx
+++ b/site/components/CiteFormatList.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useState } from 'react'
+
+import { CITE_FORMATS, renderCite, type CiteFormat, type CiteSource } from '@/lib/cite'
+
+/**
+ * Every citation format for one norma, each copyable.
+ *
+ * The strings are rendered on the client rather than passed down pre-rendered
+ * because two of them embed today's date (BibTeX `urldate`, RIS `Y2`). Rendered
+ * on the server they would be baked into a cached page and slowly go stale —
+ * an access date that predates the visit is wrong in a way nobody would notice.
+ */
+export function CiteFormatList({ source }: { source: CiteSource }) {
+  const [copied, setCopied] = useState<CiteFormat | null>(null)
+
+  async function copy(fmt: CiteFormat, text: string) {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(fmt)
+      setTimeout(() => setCopied(null), 1600)
+    } catch {
+      // Unavailable over plain HTTP; the text is selectable regardless.
+    }
+  }
+
+  return (
+    <div className="space-y-2.5">
+      {CITE_FORMATS.map((f) => {
+        const text = renderCite(f.id, source)
+        const multiline = text.includes('\n')
+        return (
+          <div
+            key={f.id}
+            className="rounded-lg border border-rule bg-paper-sunk overflow-hidden"
+          >
+            <div className="flex items-center justify-between gap-3 px-3.5 pt-2 pb-1.5 border-b border-rule/60">
+              <span className="text-[10.5px] uppercase tracking-[0.16em] text-ink-faint">
+                {f.label}
+                {f.hint && <span className="ml-2 normal-case tracking-normal">· {f.hint}</span>}
+              </span>
+              <button
+                onClick={() => copy(f.id, text)}
+                className="text-[10.5px] uppercase tracking-[0.12em] text-ink-faint hover:text-indigo transition-colors"
+              >
+                {copied === f.id ? 'copiado' : 'copiar'}
+              </button>
+            </div>
+            <p
+              className={`px-3.5 py-2.5 text-ink-soft ${
+                multiline
+                  ? 'font-mono text-[12px] leading-relaxed whitespace-pre overflow-x-auto'
+                  : 'text-[13.5px] leading-relaxed break-words'
+              }`}
+            >
+              {text}
+            </p>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/site/content/posts/citar-ley-apa.tsx
+++ b/site/content/posts/citar-ley-apa.tsx
@@ -1,0 +1,104 @@
+import Link from 'next/link'
+
+import { normaHref } from '@/lib/href'
+import { Callout, Facts, H2, NormaLink, P } from '@/components/seo/Editorial'
+
+/** Targets "cómo citar una ley en APA" and "citar ley APA 7", the highest-volume
+ *  variants. Deliberately honest that APA does not settle the Chilean case —
+ *  a guide that pretends otherwise gets students marked down. */
+export default function Post() {
+  return (
+    <>
+      <P>
+        APA 7 dedica un capítulo entero a materiales legales, y casi todo él describe el sistema
+        estadounidense. Para legislación de otros países la norma dice, en resumen, que se siga la
+        convención local adaptada al formato APA. Eso deja al estudiante chileno sin una regla
+        explícita. Esto es lo más cercano a una.
+      </P>
+
+      <H2>La estructura</H2>
+
+      <P>
+        APA ordena una referencia en cuatro bloques: quién, cuándo, qué y dónde. Aplicado a una
+        norma chilena, el «quién» y el «qué» se funden en el nombre de la norma, el «cuándo» es la
+        publicación en el Diario Oficial, y el «dónde» es la URL.
+      </P>
+
+      <Facts
+        rows={[
+          { k: 'Autor / título', v: 'Ley N° 21.719' },
+          { k: 'Fecha', v: '(2024, 26 de agosto)' },
+          { k: 'Fuente', v: 'Diario Oficial de la República de Chile' },
+          { k: 'URL', v: 'https://leyes.pisanvs.cl/…' },
+        ]}
+      />
+
+      <P>Queda así, para la referencia de la{' '}
+        <NormaLink href={normaHref('ley', '21719')}>Ley 21.719</NormaLink>:
+      </P>
+
+      <Facts
+        rows={[
+          {
+            k: 'Referencia',
+            v: 'Ley N° 21.719. (2024, 26 de agosto). Diario Oficial de la República de Chile. https://leyes.pisanvs.cl/…',
+          },
+          { k: 'Cita en el texto', v: '(Ley N° 21.719, 2024)' },
+        ]}
+      />
+
+      <H2>Citar un artículo</H2>
+
+      <P>
+        El artículo va junto al nombre de la norma, no como número de página:
+      </P>
+
+      <Facts
+        rows={[
+          {
+            k: 'Referencia',
+            v: 'Ley N° 21.719, art. 12. (2024, 26 de agosto). Diario Oficial de la República de Chile. https://…',
+          },
+          { k: 'Cita en el texto', v: '(Ley N° 21.719, art. 12, 2024)' },
+        ]}
+      />
+
+      <H2>Los puntos en el número</H2>
+
+      <P>
+        En Chile los números de ley se escriben con separador de miles: «Ley N° 21.719», no «Ley N°
+        21719». Es la forma que usa el propio Diario Oficial, y la que espera cualquier lector
+        chileno.
+      </P>
+
+      <H2>Lo que APA no resuelve</H2>
+
+      <Callout>
+        Nada de lo anterior es una regla oficial de APA para normas chilenas, porque esa regla no
+        existe. Es una lectura defendible del estándar. Si tu facultad publica una guía propia, esa
+        guía manda.
+      </Callout>
+
+      <P>
+        Hay además un problema que APA no contempla en absoluto: el texto de una ley cambia. APA
+        asume que una fuente publicada es estable, y una ley no lo es. Si tu trabajo analiza un
+        hecho anterior a una reforma, la referencia debería indicar qué versión leíste — algo que
+        ningún estándar internacional pide todavía, pero que cualquier lector agradece. Lo tratamos
+        en{' '}
+        <Link href="/blog/citar-version-historica">
+          cómo citar la versión de una ley que ya no rige
+        </Link>
+        .
+      </P>
+
+      <H2>Generarla automáticamente</H2>
+
+      <P>
+        <Link href="/citar">La herramienta de citación</Link> entrega la referencia APA de
+        cualquier norma chilena, y también BibTeX y RIS si trabajas con Zotero o Mendeley. La guía
+        completa, con los otros formatos, está en{' '}
+        <Link href="/blog/citar-ley-chilena">cómo citar una ley chilena</Link>.
+      </P>
+    </>
+  )
+}

--- a/site/content/posts/citar-ley-chilena.tsx
+++ b/site/content/posts/citar-ley-chilena.tsx
@@ -1,0 +1,122 @@
+import Link from 'next/link'
+
+import { normaHref } from '@/lib/href'
+import { Callout, Facts, H2, NormaLink, P } from '@/components/seo/Editorial'
+
+/** Hub of the citation cluster. Targets "cómo citar una ley chilena" and its
+ *  variants; the APA-specific and version-specific posts link back here.
+ *
+ *  Every example is a real norma, and the numbers (227 DFL 1, 525 DTO 1, 122
+ *  versions of the Código Penal, 3,703 undated normas) come from corpus queries
+ *  on 2026-09-10. */
+export default function Post() {
+  return (
+    <>
+      <P>
+        Citar una ley chilena parece trivial hasta que hay que hacerlo bien. El número no
+        identifica la norma, el texto cambia con los años, y ni APA ni MLA dicen con claridad qué
+        hacer con legislación chilena. Esta guía resuelve los cuatro casos que aparecen de verdad.
+      </P>
+
+      <H2>La cita legal chilena</H2>
+
+      <P>
+        El uso chileno cita la norma, el artículo cuando corresponde, el Diario Oficial y la fecha
+        de publicación. Para la{' '}
+        <NormaLink href={normaHref('ley', '21719')}>Ley 21.719</NormaLink>, sobre protección de
+        datos personales:
+      </P>
+
+      <Facts
+        rows={[
+          { k: 'Norma completa', v: 'Ley N° 21.719, Diario Oficial, 26 de agosto de 2024.' },
+          { k: 'Un artículo', v: 'Ley N° 21.719, art. 12, Diario Oficial, 26 de agosto de 2024.' },
+        ]}
+      />
+
+      <P>
+        Es la forma que no está en disputa. Si tu facultad no exige un estándar internacional,
+        usa esta.
+      </P>
+
+      <H2>APA, MLA y Chicago</H2>
+
+      <P>
+        Los tres estándares fueron escritos pensando en legislación estadounidense y remiten a la
+        convención local para el resto. No existe una versión oficial para normas chilenas, así que
+        lo que sigue es una lectura razonable de cada uno, no una regla:
+      </P>
+
+      <Facts
+        rows={[
+          {
+            k: 'APA 7',
+            v: 'Ley N° 21.719, art. 12. (2024, 26 de agosto). Diario Oficial de la República de Chile. https://…',
+          },
+          {
+            k: 'MLA 9',
+            v: '"Ley N° 21.719, art. 12." Diario Oficial de la República de Chile, 26 ago. 2024, leyes.pisanvs.cl/…',
+          },
+          {
+            k: 'Chicago',
+            v: 'Ley N° 21.719, art. 12, Diario Oficial, 26 de agosto de 2024, https://…',
+          },
+        ]}
+      />
+
+      <Callout>
+        Antes de entregar un trabajo, revisa la guía de tu facultad. Varias escuelas de derecho
+        chilenas tienen reglas propias que priman sobre APA o MLA, y ninguna de las tres normas
+        internacionales zanja el caso chileno.
+      </Callout>
+
+      <H2>El número no identifica la norma</H2>
+
+      <P>
+        Este es el error que más se repite, y no es evidente. En el corpus chileno hay{' '}
+        <strong>227 normas llamadas «DFL 1»</strong> y <strong>525 llamadas «DTO 1»</strong>, de
+        distintos ministerios y distintos años. «DFL 1» no es una cita: es una familia de normas.
+      </P>
+
+      <P>
+        Una cita de un decreto o un DFL tiene que incluir el organismo y el año, o bien el
+        identificador único de la norma. Sin eso, quien lea tu trabajo no puede llegar al texto que
+        leíste.
+      </P>
+
+      <H2>El texto cambia, y la cita apunta a un texto</H2>
+
+      <P>
+        El <NormaLink href="/norma/1984">Código Penal</NormaLink> tiene 122 versiones
+        desde 1874. La <NormaLink href={normaHref('ley', '19496')}>ley del consumidor</NormaLink>,
+        nueve. Si tu trabajo analiza un hecho de 2015 y tu cita enlaza al texto vigente hoy, la
+        cita contradice lo que estás comentando.
+      </P>
+
+      <P>
+        Una cita completa indica la versión. Es el caso que casi ninguna guía cubre, y el que más
+        importa en trabajos que analizan hechos pasados. Lo desarrollamos en{' '}
+        <Link href="/blog/citar-version-historica">
+          cómo citar la versión de una ley que ya no rige
+        </Link>
+        .
+      </P>
+
+      <H2>Normas sin fecha</H2>
+
+      <P>
+        3.703 normas del corpus no tienen fecha de publicación registrada. Cuando falta, APA y MLA
+        usan «s. f.» (sin fecha). Inventar una fecha aproximada es peor que declarar que no se
+        conoce.
+      </P>
+
+      <H2>Hazlo automáticamente</H2>
+
+      <P>
+        En <Link href="/citar">la herramienta de citación</Link> puedes buscar cualquier norma,
+        elegir la versión, y copiar la cita en los ocho formatos. Dentro del lector, cada artículo
+        tiene un botón «citar» que hace lo mismo para ese artículo en particular.
+      </P>
+    </>
+  )
+}

--- a/site/content/posts/citar-version-historica.tsx
+++ b/site/content/posts/citar-version-historica.tsx
@@ -1,0 +1,102 @@
+import Link from 'next/link'
+
+import { normaHref } from '@/lib/href'
+import { Callout, Facts, H2, NormaLink, P } from '@/components/seo/Editorial'
+
+/** The post only this corpus can write. Targets "citar una ley derogada",
+ *  "citar versión anterior de una ley" and the long tail around them — low
+ *  volume individually, but no competition and perfect intent. */
+export default function Post() {
+  return (
+    <>
+      <P>
+        Una cita apunta a un texto. El problema es que el texto de una ley no es uno: es una serie.
+        El <NormaLink href="/norma/1984">Código Penal</NormaLink> ha tenido 122 redacciones
+        distintas desde 1874. Citar «el Código Penal» sin más es citar una de ellas sin decir cuál.
+      </P>
+
+      <P>
+        Para la mayoría de los trabajos eso da igual, porque se comenta la ley vigente. Deja de dar
+        igual en cuanto el trabajo analiza un hecho del pasado — que es casi todo el derecho.
+      </P>
+
+      <H2>El error, concretamente</H2>
+
+      <P>
+        Supón que analizas un despido de 2019 y citas el artículo 161 del{' '}
+        <NormaLink href="/norma/207436">Código del Trabajo</NormaLink>. Tu lector
+        sigue el enlace, llega al texto de hoy, y lee una redacción que en 2019 no existía. Tu
+        argumento se apoya en un texto; tu cita entrega otro. Nadie mintió, pero la cita no prueba
+        lo que dice probar.
+      </P>
+
+      <Callout>
+        Esto no es hipotético. Casi todos los sitios legales — incluido el oficial — muestran
+        únicamente el texto vigente. Un enlace a una ley es, en la práctica, un enlace a su versión
+        de hoy, sea cual sea la fecha del hecho que comentas.
+      </Callout>
+
+      <H2>Qué debería incluir la cita</H2>
+
+      <P>
+        Ningún estándar internacional lo exige todavía, pero la información necesaria es simple: la
+        norma, el artículo, y la fecha de la versión que leíste.
+      </P>
+
+      <Facts
+        rows={[
+          {
+            k: 'Incompleta',
+            v: 'Ley N° 19.496, art. 3, Diario Oficial, 7 de marzo de 1997.',
+          },
+          {
+            k: 'Completa',
+            v: 'Ley N° 19.496, art. 3, texto vigente al 13 de diciembre de 2013, Diario Oficial, 7 de marzo de 1997.',
+          },
+        ]}
+      />
+
+      <P>
+        La primera indica cuándo se publicó la ley. La segunda indica qué texto leíste — que es lo
+        que a tu lector le hace falta para verificarte.
+      </P>
+
+      <H2>Cómo saber qué versión corresponde</H2>
+
+      <P>
+        La <NormaLink href={normaHref('ley', '19496')}>ley del consumidor</NormaLink> tiene nueve
+        versiones. Para un contrato firmado en marzo de 2013, la que regía es la que empezó el 21 de
+        octubre de 2011 y terminó el 12 de diciembre de 2013:
+      </P>
+
+      <Facts
+        rows={[
+          { k: '2011-10-21 → 2013-12-12', v: 'La versión que regía en marzo de 2013' },
+          { k: '2013-12-13 → 2014-06-08', v: 'Ley 20.715 ya la había modificado' },
+        ]}
+      />
+
+      <P>
+        En el lector, cada versión tiene su propia URL con la fecha, así que el enlace que copias
+        apunta al texto correcto y sigue apuntando ahí cuando la ley vuelva a cambiar.
+      </P>
+
+      <H2>Leyes derogadas</H2>
+
+      <P>
+        Una ley derogada no desaparece: sigue siendo la norma aplicable a los hechos ocurridos
+        mientras regía. Se cita igual, indicando la versión, y conviene señalar la derogación
+        cuando es relevante para el argumento.
+      </P>
+
+      <H2>Hacerlo sin pensarlo</H2>
+
+      <P>
+        En <Link href="/citar">la herramienta de citación</Link> puedes elegir la versión y copiar
+        la cita ya fechada, en cualquiera de los ocho formatos. La guía general está en{' '}
+        <Link href="/blog/citar-ley-chilena">cómo citar una ley chilena</Link>, y el detalle de APA
+        en <Link href="/blog/citar-ley-apa">cómo citar una ley en APA 7</Link>.
+      </P>
+    </>
+  )
+}

--- a/site/lib/blog.ts
+++ b/site/lib/blog.ts
@@ -2,6 +2,9 @@ import type { ComponentType } from 'react'
 import KarinReajuste from '@/content/posts/ley-karin-reajuste'
 import LeerEnFecha from '@/content/posts/leer-la-ley-en-una-fecha'
 import Datos21719 from '@/content/posts/ley-21719-datos-personales'
+import CitarLeyChilena from '@/content/posts/citar-ley-chilena'
+import CitarLeyApa from '@/content/posts/citar-ley-apa'
+import CitarVersionHistorica from '@/content/posts/citar-version-historica'
 
 export interface PostMeta {
   slug: string
@@ -24,6 +27,39 @@ export interface Post extends PostMeta {
  *  content directory traced into the bundle, which is a footgun for no gain at
  *  this volume. Adding a post = a file plus a line here. */
 export const POSTS: Post[] = [
+  {
+    slug: 'citar-ley-chilena',
+    title: 'Cómo citar una ley chilena: guía con ejemplos',
+    description:
+      'El formato legal chileno, APA 7, MLA 9 y Chicago, con ejemplos reales. Incluye cómo citar un artículo, por qué «DFL 1» no identifica una norma, y qué hacer cuando el texto cambió.',
+    standfirst:
+      'El número no identifica la norma, el texto cambia con los años, y ni APA ni MLA dicen qué hacer con legislación chilena. Los cuatro casos que aparecen de verdad.',
+    published: '2026-09-10',
+    tags: ['citación', 'APA', 'guía'],
+    Body: CitarLeyChilena,
+  },
+  {
+    slug: 'citar-ley-apa',
+    title: 'Cómo citar una ley chilena en APA 7',
+    description:
+      'APA dedica un capítulo a materiales legales y casi todo describe el sistema estadounidense. Esto es lo más cercano a una regla para normas chilenas, con referencia y cita en el texto.',
+    standfirst:
+      'APA remite a «la convención local» para legislación extranjera. Eso deja al estudiante chileno sin regla explícita.',
+    published: '2026-09-10',
+    tags: ['citación', 'APA', 'guía'],
+    Body: CitarLeyApa,
+  },
+  {
+    slug: 'citar-version-historica',
+    title: 'Cómo citar la versión de una ley que ya no rige',
+    description:
+      'El Código Penal tiene 122 redacciones distintas desde 1874. Si tu trabajo analiza un hecho de 2019 y tu cita enlaza al texto de hoy, la cita no prueba lo que dice probar.',
+    standfirst:
+      'Una cita apunta a un texto. El texto de una ley no es uno: es una serie. Citar sin la fecha es citar una versión sin decir cuál.',
+    published: '2026-09-10',
+    tags: ['citación', 'versiones', 'corpus'],
+    Body: CitarVersionHistorica,
+  },
   {
     slug: 'ley-karin-reajuste',
     title: 'La ley que modificó la Ley Karin era una ley de reajuste de sueldos',

--- a/site/lib/jsonld.test.ts
+++ b/site/lib/jsonld.test.ts
@@ -61,7 +61,7 @@ describe('cleanTitulo', () => {
 
 describe('RESERVED_TIPOS', () => {
   it('protects app routes from the tipo namespace', () => {
-    for (const r of ['buscar', 'api', 'sitemap', '_next']) {
+    for (const r of ['buscar', 'api', 'sitemap', '_next', 'citar']) {
       expect(RESERVED_TIPOS.has(r)).toBe(true)
     }
     expect(RESERVED_TIPOS.has('ley')).toBe(false)

--- a/site/lib/jsonld.ts
+++ b/site/lib/jsonld.ts
@@ -14,7 +14,7 @@ export { SITE }
  *  otherwise shadow ~7.8k law URLs silently. */
 export const RESERVED_TIPOS = new Set([
   'buscar', 'api', 'sitemap', 'robots', '_next',
-  'guia', 'cambios', 'temas', 'blog', 'norma',
+  'guia', 'cambios', 'temas', 'blog', 'norma', 'citar',
 ])
 
 /** Some títulos are stored with the line breaks the BCN source wrapped them


### PR DESCRIPTION
Reopens #30, which GitHub auto-closed when #29 merged and its base branch `feat/cite-button` was deleted. Same commit, rebased onto the squashed `deploy/railway`; #29 is already in.

### Why this cluster

"ley 21719" is a query BCN will always win — they are the official source and the domain authority is not close. "cómo citar una ley chilena" is not: the results are generic APA explainers that never mention Chile, the competition is weak, and the intent is exact. Whoever searches it is writing something and needs a citation now, which is precisely what #29's button produces.

### `/citar` — a tool, not just an article

Server-rendered, with search and version selection as plain GET parameters. The guide is in the HTML and the whole thing works with JavaScript disabled; only the copy buttons are client-side.

It is a tool because a free tool that does the job gets linked, and blog posts mostly do not — and inbound links are the actual constraint on this domain right now. Same reason it lives at `/citar` rather than inside `/blog`.

`FAQPage` JSON-LD via the `faqJsonLd` helper that already existed in `lib/jsonld.ts` and had no callers.

### Three posts

| Slug | Target |
|---|---|
| `citar-ley-chilena` | the hub — every format, articles, the DFL ambiguity, undated normas |
| `citar-ley-apa` | "cómo citar una ley en APA", the highest-volume variant |
| `citar-version-historica` | the post only this corpus can write |

All three say plainly that APA and MLA do not settle the Chilean case — they were written for US law and defer to local convention for everything else. A guide that papers over that gets students marked down, which is the opposite of the intended effect.

The version post is the one worth having. Every other legal site shows only the text in force today, so a link to a law is in practice a link to its current version regardless of when the events discussed happened. Citing art. 161 of the Código del Trabajo for a 2019 dismissal and linking to today's text is an argument whose citation does not support it.

### Two content errors, caught before shipping

Every norma cited was checked against production, and two did not survive:

- `normaHref('cod', '1')` **404s**. `/cod/1` is not a valid path, and that link was in two posts.
- One of them labelled it *"Código del Trabajo"*. `cod 1` is the **Código Penal**; the Código del Trabajo is DFL 1 of the Ministerio del Trabajo, `idNorma` 207436.

Both now link by `idNorma`. The ley 19.496 version windows quoted in the version post (`2011-10-21 → 2013-12-12`) were verified against its nine real versions. A mislabelled norma on a legal site costs exactly the trust the outreach strategy depends on.

### Also

`'citar'` added to `RESERVED_TIPOS` — otherwise `/citar/algo` tries to resolve as a norma under `[tipo]/[numero]`. Test asserts it.

### Caveat, restated from #29

Citing Chilean legislation in APA and MLA is genuinely under-specified. The posts say so, but I would still have a law student check the output against their faculty's guide before this gets promoted anywhere.

### Verification

`tsc --noEmit` clean · 323 tests pass, 2 skipped · `next build` compiles with `/citar` dynamic and all three posts prerendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5a463XjtoDsYpMC7Vzhi6
