### PR TITLE
fix(efectos): dropped text, mis-attributed códigos, and a backwards whole-law diff

### DIFF
--- a/site/components/EfectosPanel.tsx
+++ b/site/components/EfectosPanel.tsx
@@ -6,154 +6,13 @@ import Link from 'next/link'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { segment, wordDiff, joinDiffText, type Segment } from '@/lib/diff'
+import { alignEffects, isWholesaleRewrite } from '@/lib/efectosAlign'
 import { canonicalHref } from '@/lib/href'
 import { escapeLegalMarkdown } from '@/lib/mdEscape'
 import type { Efecto, EfectoArticle } from '@/lib/efectos'
 
 const TIPO_LABEL: Record<string, string> = {
   ley: 'Ley', dl: 'DL', dfl: 'DFL', dto: 'Decreto', cod: 'Código', res: 'Resolución',
-}
-
-// ---------------------------------------------------------------------------
-// Aligning each effect to the modifier article that caused it.
-//
-// A Chilean modificatoria names its target inside each article: "Modifícase el
-// decreto con fuerza de ley N° 5, de 1967 … en el siguiente sentido:". So the
-// target (tipo, numero) can be recovered from the article text and matched to
-// the effect on that same law — which is what lets the change sit next to the
-// article that produced it, rather than in a flat list.
-//
-// Heuristic, not a parser: it requires the tipo cue and the number in
-// proximity, so an incidental "artículo 5" doesn't get read as "DFL 5". What it
-// cannot match (an unusual reference, a table) falls to "Otras modificaciones".
-// ---------------------------------------------------------------------------
-
-const TIPO_CUE: Record<string, string> = {
-  dfl: 'fuerza de ley',
-  dl: 'decreto\\s+ley',
-  dto: 'decreto(?:\\s+supremo)?',
-  ley: 'ley',
-  cod: 'c[oó]digo',
-}
-
-/** Collapse thousands separators inside numbers ("19.882" → "19882") so a bare
- *  number match is reliable. */
-function collapseNums(s: string): string {
-  let prev = ''
-  let out = s
-  while (out !== prev) {
-    prev = out
-    out = out.replace(/(\d)\.(\d)/g, '$1$2')
-  }
-  return out
-}
-
-/** Strict reference: the tipo cue and the number in proximity. Rules out an
- *  incidental "artículo 5" being read as "DFL 5". */
-function strictPattern(tipo: string, numero: string): RegExp | null {
-  const num = numero.replace(/\D/g, '')
-  const cue = TIPO_CUE[tipo]
-  if (!num || !cue) return null
-  return new RegExp(`${cue}[^.;:]{0,60}?n[°ºo]?\\s*${num}\\b`, 'i')
-}
-
-const fold = (s: string) =>
-  s.normalize('NFKD').replace(/[̀-ͯ]/g, '').toLowerCase()
-
-// Title words too generic to identify a law on their own — a modifier article
-// that merely says "código" or "ley general" must not match by them.
-const NAME_STOPWORDS = new Set([
-  'codigo', 'ley', 'sobre', 'general', 'generales', 'normas', 'norma', 'sistema',
-  'nacional', 'servicio', 'servicios', 'ministerio', 'establece', 'texto',
-  'refundido', 'coordinado', 'sistematizado', 'organica', 'organico',
-  'constitucional', 'materia', 'materias', 'disposiciones', 'aprueba', 'crea',
-  'fija', 'estatuto', 'sector', 'publico', 'del', 'los', 'las', 'para',
-])
-
-/** Distinctive words from a target's title and common names ("aeronautico",
- *  "municipalidades") — long enough and specific enough to identify the law when
- *  a modifier article names it instead of numbering it. */
-function nameTokens(titulo: string, comunes: string[]): string[] {
-  const seen = new Set<string>()
-  for (const src of [...comunes, titulo]) {
-    for (const w of fold(src).split(/[^a-z0-9]+/)) {
-      if (w.length >= 7 && !NAME_STOPWORDS.has(w)) seen.add(w)
-    }
-  }
-  return Array.from(seen)
-}
-
-interface AlignedRow {
-  article: Segment
-  efectos: Efecto[]
-}
-
-/** Pair each effect with the modifier article that caused it.
- *
- *  Two passes, most confident first:
- *   1. strict — tipo cue + number in proximity ("fuerza de ley N° 5").
- *   2. fuzzy  — for still-unmatched effects on a law with a distinctive number
- *      (≥ 1000, so not confusable with an article number), the number appearing
- *      anywhere in an as-yet-unmatched article. Catches references that name the
- *      law without a clean tipo cue ("lo dispuesto en la N° 19.880").
- *  Whatever neither pass claims falls to "Otras". */
-function alignEffects(
-  articles: Segment[],
-  efectos: Efecto[],
-): { rows: AlignedRow[]; unmatched: Efecto[] } {
-  const bodies = articles.map((a) => collapseNums(a.body))
-  const rows: AlignedRow[] = articles.map((article) => ({ article, efectos: [] }))
-  const taken = new Set<number>()
-
-  const assign = (test: (body: string, e: Efecto) => boolean) => {
-    efectos.forEach((e, ei) => {
-      if (taken.has(ei)) return
-      const ai = bodies.findIndex((b, i) => test(b, e) && rowFree(rows[i], e))
-      if (ai >= 0) {
-        rows[ai].efectos.push(e)
-        taken.add(ei)
-      }
-    })
-  }
-
-  // Pass 1 — strict: tipo cue + number in proximity ("fuerza de ley N° 5").
-  const strict = efectos.map((e) => strictPattern(e.target.tipo, e.target.numero))
-  assign((body, e) => {
-    const p = strict[efectos.indexOf(e)]
-    return !!p && p.test(body)
-  })
-  // Pass 2 — number-only, for distinctive numbers (≥4 digits), matched against
-  // the dot-collapsed body.
-  assign((body, e) => {
-    const num = e.target.numero.replace(/\D/g, '')
-    return num.length >= 4 && new RegExp(`(^|\\D)${num}(\\D|$)`).test(body)
-  })
-  // Pass 3 — by name: laws cite a code by its name, not its number ("en el
-  // artículo 193 del Código Aeronáutico"). Match a distinctive title/common-name
-  // word of the target against the accent-folded article body.
-  const tokens = efectos.map((e) => nameTokens(e.target.titulo, e.target.nombresUsoComun))
-  const folded = bodies.map(fold)
-  efectos.forEach((e, ei) => {
-    if (taken.has(ei)) return
-    const toks = tokens[ei]
-    if (toks.length === 0) return
-    const ai = folded.findIndex(
-      (fb, i) => toks.some((t) => fb.includes(t)) && rowFree(rows[i], e),
-    )
-    if (ai >= 0) {
-      rows[ai].efectos.push(e)
-      taken.add(ei)
-    }
-  })
-
-  const unmatched = efectos.filter((_, i) => !taken.has(i))
-  return { rows, unmatched }
-}
-
-/** Don't stack two effects on one article unless it really names both — keeps a
- *  fuzzy pass from dumping several laws onto one long article. */
-function rowFree(row: AlignedRow, _e: Efecto): boolean {
-  return row.efectos.length < 3
 }
 
 /** Efectos mode: the modificatoria's own articles, with each change aligned to
@@ -176,11 +35,6 @@ export function EfectosAligned({ modifierId, text }: { modifierId: number; text:
     [articles, q.data],
   )
 
-  // Only the articles that actually change another law get a row. Showing the
-  // ~130 substantive articles that modify nothing (with an empty column beside
-  // them) is what made this read as broken. The full text stays one click away
-  // in the Limpio / Redline modes.
-  const modifying = rows.filter((r) => r.efectos.length > 0)
   const totalEfectos = q.data?.efectos.length ?? 0
 
   if (q.isLoading) return <p className="text-sm text-ink-faint">Calculando efectos…</p>
@@ -209,19 +63,32 @@ export function EfectosAligned({ modifierId, text }: { modifierId: number; text:
           viewport. Rows separated by a rule; within a row, a vertical line
           divides the modifier article (left) from what it changed (right). */}
       <div className="@container divide-y divide-rule">
-        {modifying.map((row) => (
-          <div
-            key={row.article.slug}
-            className="grid grid-cols-1 @3xl:grid-cols-2 gap-x-12 gap-y-4 py-7"
-          >
-            <ModifierArticle article={row.article} />
-            <div className="space-y-6 @3xl:border-l @3xl:border-rule @3xl:pl-12">
-              {row.efectos.map((e) => (
-                <TargetEffect key={`${e.target.idNorma}:${e.fecha}`} efecto={e} />
-              ))}
+        {/* Every article is rendered, in document order — including the ones
+            that change nothing. Those take the full width rather than sitting
+            beside an empty column, which is what made showing them read as
+            broken before. Dropping them instead deleted parts of the law: a
+            modificatoria's quoted insertions are emitted as articles of the
+            modifier, so filtering by "has effects" truncated the text
+            mid-sentence. See lib/efectosAlign. */}
+        {rows.map((row, i) =>
+          row.efectos.length === 0 ? (
+            <div key={`${row.article.slug}:${i}`} className="py-6">
+              <ModifierArticle article={row.article} />
             </div>
-          </div>
-        ))}
+          ) : (
+            <div
+              key={`${row.article.slug}:${i}`}
+              className="grid grid-cols-1 @3xl:grid-cols-2 gap-x-12 gap-y-4 py-7"
+            >
+              <ModifierArticle article={row.article} />
+              <div className="space-y-6 @3xl:border-l @3xl:border-rule @3xl:pl-12">
+                {row.efectos.map((e) => (
+                  <TargetEffect key={`${e.target.idNorma}:${e.fecha}`} efecto={e} />
+                ))}
+              </div>
+            </div>
+          ),
+        )}
 
         {unmatched.length > 0 && (
           <section className="py-7">
@@ -277,15 +144,49 @@ function TargetEffect({ efecto }: { efecto: Efecto }) {
         </span>
       </Link>
       <p className="text-[12px] leading-snug text-ink-faint mb-3 line-clamp-2">{target.titulo}</p>
-      <div className="space-y-4">
-        {articles.map((a) => (
-          <ArticleRedline key={`${a.slug}:${a.status}`} article={a} />
-        ))}
-        {more > 0 && (
-          <p className="text-[12px] text-ink-faint">…y {more} artículo(s) más</p>
-        )}
-      </div>
+      {isWholesaleRewrite(efecto) ? (
+        <WholesaleNotice efecto={efecto} />
+      ) : (
+        <div className="space-y-4">
+          {articles.map((a, i) => (
+            <ArticleRedline key={`${a.slug}:${a.status}:${i}`} article={a} />
+          ))}
+          {more > 0 && (
+            <p className="text-[12px] text-ink-faint">…y {more} artículo(s) más</p>
+          )}
+        </div>
+      )}
     </div>
+  )
+}
+
+/**
+ * Shown instead of the redlines when the diff covers nearly the whole target.
+ *
+ * The panel's claim is "this article changed that text", and here the corpus
+ * cannot support it: the comparison version's stored text is not the text that
+ * was in force on its date, so the redline would be both wrong and backwards.
+ * Saying so is the honest option — silently hiding the effect would misstate
+ * what the law did just as badly, in the other direction.
+ */
+function WholesaleNotice({ efecto }: { efecto: Efecto }) {
+  const n = efecto.articles.length + efecto.more
+  return (
+    <details className="rounded-lg border border-dashed border-rule bg-paper-sunk/40 px-3.5 py-3">
+      <summary className="cursor-pointer text-[12.5px] text-ink-soft marker:text-ink-faint">
+        Texto completo re-transcrito ({n} artículos)
+      </summary>
+      <p className="mt-2 text-[12px] leading-relaxed text-ink-faint">
+        La versión anterior guardada en el corpus no corresponde al texto vigente en esa fecha, así
+        que la comparación marca casi todos los artículos como modificados. No refleja lo que esta
+        norma cambió. Para ver el cambio real, abre la norma y compara sus versiones.
+      </p>
+      <div className="mt-3 space-y-4 opacity-60">
+        {efecto.articles.slice(0, 3).map((a, i) => (
+          <ArticleRedline key={`${a.slug}:${a.status}:${i}`} article={a} />
+        ))}
+      </div>
+    </details>
   )
 }
 

--- a/site/lib/__fixtures__/efectos/1040829.json
+++ b/site/lib/__fixtures__/efectos/1040829.json
@@ -1,0 +1,257 @@
+{
+  "efectos": [
+    {
+      "target": {
+        "idNorma": 1984,
+        "tipo": "cod",
+        "numero": "PENAL",
+        "titulo": "CÓDIGO PENAL",
+        "nombresUsoComun": []
+      },
+      "fecha": "2012-06-08",
+      "more": 0,
+      "articles": [
+        {
+          "slug": "art-21",
+          "label": "articulo 21",
+          "rawHeading": "Artículo 21",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-49",
+          "label": "articulo 49",
+          "rawHeading": "Artículo 49",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-49-bis",
+          "label": "articulo 49 bis",
+          "rawHeading": "Artículo 49 bis",
+          "status": "added",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-49-ter",
+          "label": "articulo 49 ter",
+          "rawHeading": "Artículo 49 ter",
+          "status": "added",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-49-quater",
+          "label": "articulo 49 quater",
+          "rawHeading": "Artículo 49 quáter",
+          "status": "added",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-49",
+          "label": "articulo 49",
+          "rawHeading": "Artículo 49",
+          "status": "added",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-49",
+          "label": "articulo 49",
+          "rawHeading": "Artículo 49",
+          "status": "added",
+          "prevBody": "",
+          "currBody": ""
+        }
+      ],
+      "totalArticles": 579
+    },
+    {
+      "target": {
+        "idNorma": 7098,
+        "tipo": "dl",
+        "numero": "3346",
+        "titulo": "FIJA EL TEXTO DE LA LEY ORGANICA DEL MINISTERIO DE JUSTICIA Y DERECHOS HUMANOS",
+        "nombresUsoComun": []
+      },
+      "fecha": "2012-06-08",
+      "more": 0,
+      "articles": [
+        {
+          "slug": "preambulo",
+          "label": "__preamble__",
+          "rawHeading": "",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-1",
+          "label": "articulo 1",
+          "rawHeading": "Artículo 1°",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-2",
+          "label": "articulo 2",
+          "rawHeading": "Artículo 2°",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-3",
+          "label": "articulo 3",
+          "rawHeading": "Artículo 3°",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-4",
+          "label": "articulo 4",
+          "rawHeading": "Artículo 4",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-5",
+          "label": "articulo 5",
+          "rawHeading": "Artículo 5°",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-7",
+          "label": "articulo 7",
+          "rawHeading": "Artículo 7°",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-8",
+          "label": "articulo 8",
+          "rawHeading": "Artículo 8°",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-9",
+          "label": "articulo 9",
+          "rawHeading": "Artículo 9°",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-10",
+          "label": "articulo 10",
+          "rawHeading": "Artículo 10",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-11",
+          "label": "articulo 11",
+          "rawHeading": "Artículo 11",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-12",
+          "label": "articulo 12",
+          "rawHeading": "Artículo 12",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-13",
+          "label": "articulo 13",
+          "rawHeading": "Artículo 13",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-14",
+          "label": "articulo 14",
+          "rawHeading": "Artículo 14",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-15",
+          "label": "articulo 15",
+          "rawHeading": "Artículo 15",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-16",
+          "label": "articulo 16",
+          "rawHeading": "Artículo 16",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-17",
+          "label": "articulo 17",
+          "rawHeading": "Artículo 17",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-1",
+          "label": "articulo 1",
+          "rawHeading": "Artículo 1°",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-2",
+          "label": "articulo 2",
+          "rawHeading": "Artículo 2°",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-14-bis",
+          "label": "articulo 14 bis",
+          "rawHeading": "Artículo 14 bis",
+          "status": "removed",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-18",
+          "label": "articulo 18",
+          "rawHeading": "Artículo 18",
+          "status": "removed",
+          "prevBody": "",
+          "currBody": ""
+        }
+      ],
+      "totalArticles": 20
+    }
+  ],
+  "truncated": false
+}

--- a/site/lib/__fixtures__/efectos/1040829.md
+++ b/site/lib/__fixtures__/efectos/1040829.md
@@ -1,0 +1,137 @@
+LEY NÚM. 20.587
+
+MODIFICA EL RÉGIMEN DE LIBERTAD CONDICIONAL Y ESTABLECE, EN CASO DE MULTA, LA PENA ALTERNATIVA DE TRABAJOS COMUNITARIOS
+
+Teniendo presente que el H. Congreso Nacional ha dado su aprobación al siguiente proyecto de ley,
+
+Proyecto de ley:
+
+#### Artículo 1º
+Introdúcense las siguientes modificaciones en el decreto ley Nº 321, de 1925, que establece la libertad condicional para los penados:
+
+1) En el artículo 4º:
+
+a) Sustitúyese el inciso primero por el siguiente:
+
+#### Artículo 4º
+La libertad condicional se concederá por resolución de una Comisión de Libertad Condicional que funcionará en la Corte de Apelaciones respectiva, durante los meses de abril y octubre de cada año, previo informe del Jefe del establecimiento en que esté el condenado.".
+
+b) Reemplázase, en el inciso final, la palabra "pedir" por "conceder".
+
+2) En el artículo 5º:
+
+a) Sustitúyese el inciso primero por el siguiente:
+
+#### Artículo 5º
+La libertad condicional se concederá por resolución de la Comisión de Libertad Condicional indicada en el artículo anterior, previos los trámites correspondientes, y se revocará del mismo modo.".
+
+b) Reemplázase, en el inciso final, la expresión "al Ministerio de Justicia" por "a la Comisión respectiva".
+
+3) Sustitúyese, en el artículo 6º, la locución "del Ministerio de Justicia" por "del presidente de la Comisión respectiva".
+
+4) Reemplázase, en el artículo 8º, la expresión "un decreto supremo" por "una resolución de la respectiva Comisión".
+
+#### Artículo 2º
+Introdúcense las siguientes modificaciones al Código Penal:
+
+1) Agrégase al final del artículo 21 el siguiente texto:
+
+"Penas sustitutivas por vía de conversión de la multa
+
+Prestación de servicios en beneficio de la comunidad.".
+
+2) Modifícase el artículo 49 de la siguiente manera:
+
+a) Sustitúyese el inciso primero por el siguiente:
+
+#### Artículo 49
+Si el sentenciado no tuviere bienes para satisfacer la multa podrá el tribunal imponer, por vía de sustitución, la pena de prestación de servicios en beneficio de la comunidad.".
+
+b) Incorpóranse, como nuevos incisos segundo y tercero, los siguientes, pasando el actual inciso segundo a ser cuarto:
+
+"Para proceder a esta sustitución se requerirá del acuerdo del condenado. En caso contrario, el tribunal impondrá, por vía de sustitución y apremio de la multa, la pena de reclusión, regulándose un día por cada tercio de unidad tributaria mensual, sin que ella pueda nunca exceder de seis meses.
+
+No se aplicará la pena sustitutiva señalada en el inciso primero ni se hará efectivo el apremio indicado en el inciso segundo, cuando, de los antecedentes expuestos por el condenado, apareciere la imposibilidad de cumplir la pena.".
+
+c) Intercálase en el inciso segundo, que ha pasado a ser cuarto, entre las palabras "Queda" y "exento", el vocablo "también"; y agrégase, a continuación de la palabra "grave", la frase "que deba cumplir efectivamente".
+
+3) Agréganse los siguientes artículos 49 bis, 49 ter, 49 quáter, 49 quinquies y 49 sexies:
+
+#### Artículo 49 bis
+La pena de prestación de servicios en beneficio de la comunidad consiste en la realización de actividades no remuneradas a favor de ésta o en beneficio de personas en situación de precariedad, coordinadas por un delegado de Gendarmería de Chile.
+
+El trabajo en beneficio de la comunidad será facilitado por Gendarmería, pudiendo establecer los convenios que estime pertinentes para tal fin con organismos públicos y privados sin fines de lucro.
+
+Gendarmería de Chile y sus delegados, y los organismos públicos y privados que en virtud de los convenios a que se refiere el inciso anterior intervengan en la ejecución de esta sanción, deberán velar por que no se atente contra la dignidad del penado en la ejecución de estos servicios.
+
+#### Artículo 49 ter
+La pena de prestación de servicios en beneficio de la comunidad se regulará en ocho horas por cada tercio de unidad tributaria mensual, sin perjuicio de la conversión establecida en leyes especiales.
+
+Su duración diaria no podrá exceder de ocho horas.
+
+En cualquier momento el condenado podrá solicitar poner término a la prestación de servicios en beneficio de la comunidad previo pago de la multa, a la que se deberán abonar las horas trabajadas.
+
+#### Artículo 49 quáter
+En caso de decretarse la sanción de prestación de servicios en beneficio de la comunidad, el delegado de Gendarmería de Chile responsable de gestionar el cumplimiento informará al tribunal que dictó la sentencia, quien a su vez notificará al Ministerio Público, al defensor y al condenado, el tipo de servicio, el lugar donde deba realizarse y el calendario de su ejecución, dentro de los treinta días siguientes a la fecha en que la condena se encontrare firme o ejecutoriada.
+
+#### Artículo 49
+quinquies. En caso de incumplimiento de la pena de servicios en beneficio de la comunidad, el delegado deberá informar al tribunal que haya impuesto la sanción.
+
+El tribunal citará a una audiencia para resolver la mantención o la revocación de la pena.
+
+#### Artículo 49
+sexies. El juez podrá revocar la pena de servicios en beneficio de la comunidad cuando el condenado:
+
+a) No se presentare, injustificadamente, ante Gendarmería de Chile a cumplir la pena en el plazo que determine el juez, el que no podrá ser menor a tres ni superior a siete días;
+
+b) Se ausentare del trabajo durante al menos dos jornadas laborales. Si el penado faltare al trabajo por causa justificada no se entenderá dicha ausencia como abandono de la actividad;
+
+c) Su rendimiento en la ejecución de los servicios fuere sensiblemente inferior al mínimo exigible, a pesar de los requerimientos del responsable del centro de trabajo, o
+
+d) Se opusiere o incumpliere de forma reiterada y manifiesta las instrucciones que se le dieren por el responsable del centro de trabajo.
+
+En caso de revocar la pena de servicios en beneficio de la comunidad, el tribunal impondrá al condenado, por vía de sustitución y apremio de la multa originalmente impuesta, la pena de reclusión, regulándose un día por cada tercio de unidad tributaria mensual, sin que ella pueda nunca exceder de seis meses.
+
+Habiéndose decretado la revocación se abonará al tiempo de reclusión un día por cada ocho horas efectivamente trabajadas en beneficio de la comunidad.
+
+Si el tribunal no revocare la pena de servicios en beneficio de la comunidad podrá ordenar que el cumplimiento de la misma se lleve a cabo en un lugar distinto a aquel en el cual originalmente se estaba ejecutando; todo lo anterior sin perjuicio de la facultad prevista en el inciso tercero del artículo 49.".
+
+#### Artículo 3º
+Sustitúyese el artículo 52 de la ley Nº 20.000, por el siguiente:
+
+#### Artículo 52
+Si el sentenciado no pagare la multa impuesta en virtud de la letra a) del artículo 50, el tribunal podrá aplicar, por vía de sustitución, la pena de asistencia obligatoria a programas de prevención hasta por 60 días, o de tratamiento o rehabilitación, en su caso, por un período de hasta 180 días, en instituciones autorizadas por el servicio de salud competente, o la pena de prestación de servicios en beneficio de la comunidad.
+
+Para proceder a cualquiera de dichas sustituciones, se requerirá del acuerdo del condenado. En caso contrario, el tribunal impondrá, por vía de sustitución y apremio de la multa, la pena de reclusión, regulándose un día por cada tercio de unidad tributaria mensual, sin que ella pueda nunca exceder de seis meses.
+
+En caso de incumplimiento de las penas de asistencia obligatoria a programas de prevención o de tratamiento o rehabilitación, el encargado de la respectiva institución informará al tribunal que haya impuesto la sanción, el que lo citará a una audiencia, conjuntamente con el condenado, su defensor y el Ministerio Público, para resolver sobre la mantención o revocación de la pena. En caso de decretarse la revocación, el tribunal impondrá al condenado la pena de reclusión, regulándose un día por cada tercio de unidad tributaria mensual, sin que ella pueda nunca exceder de seis meses.
+
+En cuanto a la regulación y revocación de la pena de servicios en favor de la comunidad, regirán las disposiciones contenidas en los artículos 49 a 49 sexies del Código Penal.
+
+Sin perjuicio de lo dispuesto en los incisos anteriores, en casos debidamente calificados el tribunal podrá eximir al condenado del pago de la multa o imponerle una inferior al mínimo establecido en la ley, debiendo dejar constancia en la sentencia o en la resolución posterior a ésta, de las razones que motivaron la decisión.".
+
+#### Artículo 4º
+Introdúcense las siguientes modificaciones en el decreto ley Nº 3.346, de 1980, que fija el texto de la Ley Orgánica del Ministerio de Justicia:
+
+1) Sustitúyese, en la letra n) del artículo 2º, la frase ", indultos y al beneficio de la libertad condicional", por "e indultos".
+
+2) Suprímese la letra a) del artículo 9º.
+
+3) Reemplázase, en la letra c) del artículo 10, la expresión "Defensa Social" por "Reinserción Social".
+
+4) Modifícase el artículo 13 de la siguiente manera:
+
+a) Reemplázase, en el encabezamiento, la expresión "Defensa Social" por "Reinserción Social".
+
+b) Sustitúyese, en el inciso final, la frase "la División de Defensa Social estará integrada por dos Departamentos: el de Defensa Social de Adultos y el de Menores", por la siguiente "la División de Reinserción Social estará integrada por dos Departamentos: el de Reinserción Social de Adultos y el de Reinserción Social Juvenil".
+
+#### Artículo 5º
+Las normas referidas a la pena de prestación de servicios en beneficio de la comunidad contenidas en los artículos 2º y 3º de esta ley se aplicarán en conformidad a un reglamento dictado por el Ministerio de Justicia.
+
+Dichos artículos entrarán a regir el día en que se publique en el Diario Oficial el reglamento a que se refiere el inciso anterior.".
+
+Y por cuanto he tenido a bien aprobarlo y sancionarlo; por tanto promúlguese y llévese a efecto como Ley de la República.
+
+Santiago, 28 de mayo de 2012.- SEBASTIÁN PIÑERA ECHENIQUE, Presidente de la República.- Teodoro Ribera Neumann, Ministro de Justicia.- Rodrigo Hinzpeter Kirberg, Ministro del Interior y Seguridad Pública.
+
+Lo que transcribo a Ud. para su conocimiento.- Atentamente, Patricia Pérez Goldberg, Subsecretaria de Justicia.

--- a/site/lib/__fixtures__/efectos/1192682.json
+++ b/site/lib/__fixtures__/efectos/1192682.json
@@ -1,0 +1,43 @@
+{
+  "efectos": [
+    {
+      "target": {
+        "idNorma": 30667,
+        "tipo": "ley",
+        "numero": "19300",
+        "titulo": "APRUEBA LEY SOBRE BASES GENERALES DEL MEDIO AMBIENTE",
+        "nombresUsoComun": []
+      },
+      "fecha": "2023-05-29",
+      "more": 0,
+      "articles": [
+        {
+          "slug": "art-2",
+          "label": "articulo 2",
+          "rawHeading": "Artículo 2°",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-43-bis",
+          "label": "articulo 43 bis",
+          "rawHeading": "Artículo 43 bis",
+          "status": "added",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-44",
+          "label": "articulo 44",
+          "rawHeading": "Artículo 44",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        }
+      ],
+      "totalArticles": 126
+    }
+  ],
+  "truncated": false
+}

--- a/site/lib/__fixtures__/efectos/1192682.md
+++ b/site/lib/__fixtures__/efectos/1192682.md
@@ -1,0 +1,84 @@
+LEY NÚM. 21.562
+
+MODIFICA LEY N° 19.300, SOBRE BASES GENERALES DEL MEDIO AMBIENTE, CON EL OBJETO DE ESTABLECER RESTRICCIONES A LA EVALUACIÓN DE PROYECTOS EN ZONAS DECLARADAS LATENTES O SATURADAS
+
+Teniendo presente que el H. Congreso Nacional ha dado su aprobación al siguiente proyecto de ley que tuvo su origen en una moción de las exdiputadas señoras Paulina Núñez Urrutia, Andrea Molina Oliva y Claudia Nogueira Fernández; del diputado señor Daniel Melo Contreras; y de los exdiputados señores Cristián Campos Jara, Gonzalo Fuenzalida Figueroa, Leopoldo Pérez Lahsen y Alejandro Santana Tirachini,
+
+Proyecto de ley:
+
+#### Artículo único
+Introdúcense las siguientes modificaciones en la ley N° 19.300, sobre Bases Generales del Medio Ambiente:
+
+1. En el artículo 2°:
+
+a) Incorpórase, a continuación de la letra k), la siguiente letra k bis):
+
+"k bis) Impacto crítico: alteración del medio ambiente, en especial de la salud y/o de los componentes ambientales, provocada directa o indirectamente por un proyecto o actividad, que no puede ser mitigada, reparada o compensada adecuadamente en conformidad con el decreto que declare la zona como latente o saturada.
+
+El reglamento establecerá los criterios específicos que permitan establecer la existencia de un impacto crítico para cada componente, tales como exposición y riesgo, o permanencia, capacidad de regeneración o renovación del recurso, y las condiciones que hacen posible la presencia de desarrollo de las especies y ecosistemas, en cuanto corresponda.".
+
+b) Sustitúyese en la letra t) la expresión ", y" por un punto y aparte.
+
+c) Agréganse las siguientes letras v) y w):
+
+"v) Plan de Prevención: instrumento de gestión ambiental que tiene por finalidad evitar que los niveles establecidos en las normas primarias y/o secundarias de calidad ambiental se encuentren en saturación, a través de la definición e implementación de medidas y acciones específicas, que logren la reducción de los niveles de concentración señalados en dichas normas por debajo de la latencia.
+
+w) Plan de Descontaminación: instrumento de gestión ambiental que, a través de la definición e implementación de medidas y acciones específicas, tiene por finalidad recuperar los niveles establecidos en las normas primarias y/o secundarias de calidad ambiental de una zona calificada como saturada por uno o más contaminantes.".
+
+2. Agrégase en el artículo 11, el siguiente inciso tercero:
+
+"Requerirán especialmente la elaboración de un Estudio de Impacto Ambiental aquellos proyectos o actividades que produzcan, como consecuencia de las emisiones estimadas del proyecto, un impacto significativo por la o las circunstancias que serán determinadas mediante el decreto que declare la zona saturada o latente, mientras no se dicten los respectivos planes de prevención o de descontaminación. Se entenderán como impacto significativo los efectos, características o circunstancias indicadas en el inciso primero.".
+
+3. Agrégase en el artículo 16, el siguiente inciso quinto:
+
+"Adicionalmente, tratándose de zonas declaradas saturadas o latentes, y mientras no se dicten los respectivos planes de prevención y/o de descontaminación, deberá ser rechazado aquel Estudio de Impacto Ambiental que, como consecuencia de las emisiones proyectadas del proyecto, en conformidad con la o las circunstancias que indique el decreto que declare la zona saturada o latente, respectivamente, produzca un impacto crítico en los componentes ambientales potencialmente afectados o en la salud de la población. Tan pronto se constate dicha circunstancia, se podrá proceder a la elaboración inmediata del Informe Consolidado de Evaluación, con una propuesta de rechazo fundada. Para efectos del presente inciso no será posible considerar la compensación de emisiones.".
+
+4. En el artículo 43:
+
+a) Intercálase el siguiente inciso segundo, nuevo, pasando el actual inciso segundo a ser inciso tercero:
+
+"El respectivo decreto que declare la zona saturada o latente referido en el inciso anterior deberá considerar, a lo menos, la cantidad de fuentes emisoras del contaminante de interés registradas en el territorio, los datos demográficos disponibles, así como cualquier otra información pública disponible relativa a grupos humanos, especies o ecosistemas vulnerables.".
+
+b) Reemplázase el inciso tercero, que ha pasado a ser inciso cuarto, por el siguiente:
+
+"El decreto supremo señalado en el inciso anterior dejará sin efecto las respectivas medidas del plan de descontaminación o de prevención, y podrá, en ambos casos, mantener vigentes aquellas que permitan evitar que los niveles señalados en las normas primarias o secundarias de calidad ambiental se encuentren en estado de latencia y las medidas destinadas a prevenir episodios críticos de contaminación. Para este caso, la revisión de la mantención de dichas medidas deberá realizarse, como máximo, cada dos años, sin perjuicio de la obligación de dictar el respectivo plan de prevención o de descontaminación, cuando corresponda. El procedimiento para la determinación de la mantención, revisión y extinción de las respectivas medidas, así como los plazos y formalidades que se requieren para dar cumplimiento a lo dispuesto en este artículo y los criterios para la revisión, serán establecidos por reglamento.".
+
+5. Incorpórase, a continuación del artículo 43, el siguiente artículo 43 bis:
+
+#### Artículo 43 bis
+Una vez declarada una zona como latente o saturada, mediante resolución suscrita por el Ministro del Medio Ambiente, se podrán adoptar, fundadamente, medidas provisionales de acuerdo a lo señalado en el artículo 32 de la ley N° 19.880, en conformidad con los antecedentes considerados en el proceso de elaboración de la norma que declara la zona como latente o saturada, así como con la norma de calidad respectiva y con la naturaleza y gravedad de afectación de los componentes ambientales y la salud de la población, durante el plazo considerado para la elaboración de anteproyecto de plan respectivo. Dichas medidas podrán mantenerse hasta la dictación del respectivo plan de prevención o descontaminación. Las medidas provisionales establecidas se extinguirán una vez publicado en el Diario Oficial el decreto que establezca el plan de prevención o descontaminación, por el solo ministerio de la ley.
+
+Las medidas provisionales podrán ser alzadas o modificadas durante el procedimiento de elaboración del plan de prevención y/o de descontaminación, de oficio o a solicitud de parte, en virtud de circunstancias sobrevinientes o que no pudieron ser tenidas en cuenta en el momento de su adopción.".
+
+6. Agréganse en el artículo 44, los siguientes incisos tercero, cuarto y quinto:
+
+"Todo plan de prevención o de descontaminación será revisado por el Ministerio del Medio Ambiente, al menos, cada cinco años, y se aplicará el mismo procedimiento señalado en el inciso anterior.
+
+El incumplimiento de los plazos dispuestos en este artículo, así como de los señalados en el artículo 32, por parte de la jefatura o jefe superior del órgano o servicio de la Administración del Estado respectivo, será sancionado con la medida disciplinaria de multa equivalente a media remuneración mensual, previa instrucción de una investigación sumaria o sumario administrativo, llevado por la Contraloría General de la República, de acuerdo a las normas de su ley orgánica y del Estatuto Administrativo.
+
+Si la autoridad o jefatura superior del órgano o servicio de la Administración del Estado sancionado persiste en su actitud, se le aplicará el doble de la sanción indicada y la suspensión en el cargo por un término de cinco días.".
+
+7. Agréganse en el artículo 46, los siguientes incisos segundo, tercero y cuarto:
+
+"En zonas declaradas como latentes o saturadas, mientras no se dicten los respectivos planes de prevención o descontaminación, los proyectos nuevos y modificaciones de proyectos existentes, sea que ingresen o no al Sistema de Evaluación de Impacto Ambiental, que estén localizados en las señaladas zonas, deberán compensar sus emisiones totales anuales en un porcentaje que será determinado mediante el decreto que declare la zona saturada o latente, si es que dichas emisiones representan un aporte superior al porcentaje fijado por el referido decreto, en relación con el respectivo contaminante o sus precursores.
+
+Una vez dictados los respectivos planes de prevención o de descontaminación, los proyectos nuevos y modificaciones de proyectos existentes deberán compensar sus emisiones, en conformidad con lo dispuesto en dichos planes.
+
+Los proyectos o actividades que se iniciaron de forma previa a la entrada en vigencia del Sistema de Evaluación de Impacto Ambiental deberán compensar sus emisiones en un porcentaje que será determinado mediante el decreto que declare la zona saturada o latente, si es que dichas emisiones representan un aporte superior al porcentaje que será fijado por el referido decreto, en relación con el respectivo contaminante o sus precursores.".
+
+## Artículos transitorios
+
+#### Artículo primero
+En el plazo de seis meses contado desde la publicación de la presente ley, el Presidente de la República, por decreto expedido a través del Ministerio del Medio Ambiente, deberá proceder a la modificación de los decretos supremos Nos 38 y 39, ambos de 2012, del Ministerio del Medio Ambiente, con el objeto de armonizar sus normas y establecer los procedimientos y plazos para la implementación de la presente ley.
+
+#### Artículo segundo
+El artículo único de la presente ley entrará en vigencia a contar de la publicación en el Diario Oficial de los reglamentos a que se refiere el artículo primero transitorio.
+
+#### Artículo tercero
+Con todo, las modificaciones referidas a los artículos 2°, 43 bis, nuevo, y 44 de la ley N° 19.300 entrarán en vigencia al momento de la publicación en el Diario Oficial de la presente ley.".
+
+Y por cuanto he tenido a bien aprobarlo y sancionarlo; por tanto, promúlguese y llévese a efecto como Ley de la República.
+
+Santiago, 18 de mayo de 2023.- GABRIEL BORIC FONT, Presidente de la República.- María Heloísa Rojas Corradi, Ministra del Medio Ambiente.
+
+Lo que transcribo para Ud. para los fines que estime pertinentes.- Ariel Espinoza G., Subsecretario (S) del Medio Ambiente.

--- a/site/lib/__fixtures__/efectos/1193333.json
+++ b/site/lib/__fixtures__/efectos/1193333.json
@@ -1,0 +1,29 @@
+{
+  "efectos": [
+    {
+      "target": {
+        "idNorma": 221322,
+        "tipo": "dfl",
+        "numero": "5",
+        "titulo": "FIJA TEXTO REFUNDIDO, CONCORDADO Y SISTEMATIZADO DE LA LEY GENERAL DE COOPERATIVAS",
+        "nombresUsoComun": [
+          "LEY DE COOPERATIVAS"
+        ]
+      },
+      "fecha": "2023-06-13",
+      "more": 0,
+      "articles": [
+        {
+          "slug": "art-58-bis",
+          "label": "articulo 58 bis",
+          "rawHeading": "Artículo 58 bis",
+          "status": "modified",
+          "prevBody": "",
+          "currBody": ""
+        }
+      ],
+      "totalArticles": 146
+    }
+  ],
+  "truncated": false
+}

--- a/site/lib/__fixtures__/efectos/1193333.md
+++ b/site/lib/__fixtures__/efectos/1193333.md
@@ -1,0 +1,18 @@
+LEY NÚM. 21.576
+
+MODIFICA LA LEY GENERAL DE COOPERATIVAS PARA REGULAR LAS MULTAS QUE AFECTEN A LAS COOPERATIVAS QUE NO CALIFIQUEN COMO DE IMPORTANCIA ECONÓMICA EN EL RÉGIMEN SANCIONATORIO DE MULTAS
+
+Teniendo presente que el H. Congreso Nacional ha dado su aprobación al siguiente proyecto de ley iniciado en moción de los Honorables senadores y senadoras señoras Carmen Gloria Aravena Acuña y Loreto Carvajal Ambiado y señor José Miguel Durana Semir, y de los exsenadores señores Álvaro Elizalde Soto y Jorge Pizarro Soto,
+
+Proyecto de ley:
+
+#### Artículo único
+Sustitúyese el inciso tercero del artículo 58 bis de la Ley General de Cooperativas, cuyo texto refundido, concordado y sistematizado fue fijado por el decreto con fuerza de ley N° 5, promulgado el año 2003 y publicado el año 2004, del Ministerio de Economía, Fomento y Reconstrucción, por el siguiente:
+
+"En el caso de las cooperativas de trabajo, campesinas, de pescadores, de abastecimiento, distribución de agua potable y escolares, que no califiquen como de importancia económica en los términos del artículo 109, y cuyo capital aportado por los socios no exceda de 20.000 unidades de fomento, las multas establecidas en el inciso primero del presente artículo deberán ser cursadas hasta por la mitad de los montos señalados.".".
+
+Y por cuanto he tenido a bien aprobarlo y sancionarlo; por tanto, promúlguese y llévese a efecto como Ley de la República.
+
+Santiago, 26 de mayo de 2023.- GABRIEL BORIC FONT, Presidente de la República.- Nicolás Grau Veloso, Ministro de Economía, Fomento y Turismo.
+
+Lo que transcribe para su conocimiento.- Saluda atentamente a usted, Javiera Petersen Muga, Subsecretaria de Economía y Empresas de Menor Tamaño.

--- a/site/lib/__fixtures__/efectos/1193517.json
+++ b/site/lib/__fixtures__/efectos/1193517.json
@@ -1,0 +1,45 @@
+{
+  "efectos": [
+    {
+      "target": {
+        "idNorma": 1007469,
+        "tipo": "dfl",
+        "numero": "1",
+        "titulo": "FIJA TEXTO REFUNDIDO, COORDINADO Y SISTEMATIZADO DE LA LEY DE TRÁNSITO",
+        "nombresUsoComun": [
+          "LEY DE TRÁNSITO"
+        ]
+      },
+      "fecha": "2023-06-16",
+      "more": 0,
+      "articles": [
+        {
+          "slug": "art-6",
+          "label": "articulo 6",
+          "rawHeading": "Artículo 6",
+          "status": "added",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-7",
+          "label": "articulo 7",
+          "rawHeading": "Artículo 7°",
+          "status": "added",
+          "prevBody": "",
+          "currBody": ""
+        },
+        {
+          "slug": "art-transitorio",
+          "label": "articulo transitorio",
+          "rawHeading": "Artículo transitorio",
+          "status": "removed",
+          "prevBody": "",
+          "currBody": ""
+        }
+      ],
+      "totalArticles": 255
+    }
+  ],
+  "truncated": false
+}

--- a/site/lib/__fixtures__/efectos/1193517.md
+++ b/site/lib/__fixtures__/efectos/1193517.md
@@ -1,0 +1,27 @@
+LEY NÚM. 21.579
+
+HABILITA UNA PRÓRROGA PROGRESIVA EN LA RENOVACIÓN DE LAS LICENCIAS DE CONDUCIR
+
+Teniendo presente que el H. Congreso Nacional ha dado su aprobación al siguiente proyecto de ley que tuvo su origen en moción de los diputados señores Jaime Sáez Quiroz, Carlos Bianchi Chelech, Félix Bugueño Sotelo, Felipe Camaño Cárdenas, Marcos Ilabaca Cerda, Jaime Mulet Martínez y las diputadas Catalina Pérez Salinas y Camila Rojas Valderrama,
+
+Proyecto de ley:
+
+#### Artículo único
+Modifícase la ley N° 18.290, de Tránsito, cuyo texto refundido, coordinado y sistematizado fue fijado por el decreto con fuerza de ley N° 1, de 2007, de los Ministerios de Transportes y Telecomunicaciones y de Justicia, de la siguiente forma:
+
+1. Sustitúyese la expresión "Artículo transitorio" que se encuentra a continuación del Artículo 5° transitorio, por la siguiente: "Artículo 6°".
+
+2. Agrégase el siguiente artículo 7° transitorio, nuevo:
+
+#### Artículo 7°
+Prorrógase por dos años, contados desde la fecha de vencimiento consignada en el documento, la vigencia de todas las licencias de conductor cuyo control correspondía realizar originalmente durante el año 2022.
+
+Prorrógase por un año, contado desde la fecha de vencimiento consignada en el documento, la vigencia de todas las licencias de conductor cuyo control corresponda realizar originalmente durante los años 2023 y 2024.
+
+Las licencias no profesionales clase B, C o especiales cuyo control corresponda realizar originalmente durante los años 2020, 2021, 2022, 2023 y 2024, se renovarán por el plazo que resta conforme lo establecido en el artículo 19, contado desde la fecha de vencimiento consignada en el documento. Para el caso de las licencias profesionales y aquellas que se hayan otorgado conforme al inciso final del artículo 22, su renovación se otorgará por el término que corresponda de acuerdo a las reglas generales.".".
+
+Y por cuanto he tenido a bien aprobarlo y sancionarlo; por tanto, promúlguese y llévese a efecto como Ley de la República.
+
+Santiago, 7 de junio de 2023.- GABRIEL BORIC FONT, Presidente de la República.- Juan Carlos Muñoz Abogabir, Ministro de Transportes y Telecomunicaciones.- Carolina Tohá Morales, Ministra del Interior y Seguridad Pública.
+
+Lo que transcribo a Ud. para su conocimiento.- Saluda atentamente a Ud., Jorge Antonio Daza Lobos, Subsecretario de Transportes.

--- a/site/lib/efectos.ts
+++ b/site/lib/efectos.ts
@@ -29,6 +29,9 @@ export interface Efecto {
   articles: EfectoArticle[]
   /** How many changed articles exist beyond those returned (cap applied). */
   more: number
+  /** Articles the target had in this version — the denominator for deciding
+   *  whether a diff is a legislative change or a re-transcription. */
+  totalArticles: number
 }
 
 // Bounds so a sweeping modificatoria ("modifica diversos cuerpos legales") can't
@@ -105,6 +108,7 @@ export async function getEfectos(
       fecha,
       articles,
       more: Math.max(0, changed.length - articles.length),
+      totalArticles: Math.max(curr.length, prev.length),
     })
   }
 

--- a/site/lib/efectosAlign.test.ts
+++ b/site/lib/efectosAlign.test.ts
@@ -1,0 +1,172 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, it, expect } from 'vitest'
+
+import { segment } from './segment'
+import {
+  alignEffects,
+  codPattern,
+  isWholesaleRewrite,
+  nameTokens,
+  strictPattern,
+} from './efectosAlign'
+import type { Efecto } from './efectos'
+
+/**
+ * Every fixture here is a real modificatoria whose Efectos tab was reported
+ * wrong, captured from production along with the effects the API returned for
+ * it. Three distinct failures are pinned below; a fourth law is included
+ * because it already worked and must keep working.
+ */
+
+const DIR = path.join(__dirname, '__fixtures__', 'efectos')
+
+function fixture(id: string): { text: string; efectos: Efecto[] } {
+  const text = readFileSync(path.join(DIR, `${id}.md`), 'utf8')
+  const { efectos } = JSON.parse(readFileSync(path.join(DIR, `${id}.json`), 'utf8')) as {
+    efectos: Efecto[]
+  }
+  return { text, efectos }
+}
+
+function run(id: string) {
+  const { text, efectos } = fixture(id)
+  const articles = segment(text)
+  return { articles, ...alignEffects(articles, efectos) }
+}
+
+/** Which target laws a row claims, as "tipo numero". */
+const targetsOf = (r: { efectos: Efecto[] }) =>
+  r.efectos.map((e) => `${e.target.tipo} ${e.target.numero}`)
+
+describe('alignEffects — no text is ever dropped', () => {
+  // The reported failure: "law not shown completely in the left side".
+  //
+  // A modificatoria's quoted insertions carry their own `#### Artículo N`
+  // heading, so segment() emits them as articles of the modifier. The panel
+  // renders only rows that have effects, which silently discarded them.
+  for (const id of ['1040829', '1192682', '1193517', '1193333']) {
+    it(`${id}: every segment of the law gets a row`, () => {
+      const { articles, rows } = run(id)
+      expect(rows.map((r) => r.article)).toEqual(articles)
+    })
+  }
+
+  it('1193517: the inserted artículo 7° transitorio is displayed, not dropped', () => {
+    // Ley 21.579 ended at "Agrégase el siguiente artículo 7° transitorio,
+    // nuevo:" — the article it inserts was nowhere on the page.
+    const { rows } = run('1193517')
+    const shown = rows.map((r) => r.article.body).join('\n')
+    expect(shown).toContain('Prorrógase por dos años')
+    expect(shown).toContain('licencias no profesionales clase B')
+  })
+
+  it('1192682: the inserted artículo 43 bis and the transitory articles survive', () => {
+    const { rows } = run('1192682')
+    const headings = rows.map((r) => r.article.rawHeading)
+    expect(headings).toContain('Artículo 43 bis')
+    expect(headings).toContain('Artículo primero')
+    // The effect belongs to the article that does the amending, not to the
+    // preamble, whose text is the law's own title: "MODIFICA LEY N° 19.300…".
+    const withEfectos = rows.filter((r) => r.efectos.length > 0)
+    expect(withEfectos).toHaveLength(1)
+    expect(withEfectos[0].article.rawHeading).toBe('Artículo único')
+    expect(targetsOf(withEfectos[0])).toEqual(['ley 19300'])
+  })
+})
+
+describe('alignEffects — códigos are matched by name', () => {
+  // The reported failure: "complete disconnection between cause and effect".
+  //
+  // A código's `numero` is a word, not a number ("PENAL"), so every numeric
+  // rule is a no-op for it. Ley 20.587 opens "Introdúcense las siguientes
+  // modificaciones en el Código Penal" and the whole Código Penal block still
+  // landed in "Otras modificaciones".
+  it('1040829: the Código Penal effect attaches to the article that names it', () => {
+    const { rows, unmatched } = run('1040829')
+    expect(unmatched.map((e) => e.target.numero)).not.toContain('PENAL')
+    const row = rows.find((r) => targetsOf(r).includes('cod PENAL'))
+    // Artículo 2º — "Introdúcense las siguientes modificaciones al Código
+    // Penal". Artículo 1º amends DL 321 and says "para los penados", which the
+    // cue requirement correctly declines to read as a Código Penal reference.
+    expect(row?.article.rawHeading).toBe('Artículo 2º')
+  })
+
+  it('codPattern requires the cue, so "penal" alone is not a Código Penal reference', () => {
+    const p = codPattern('PENAL')!
+    expect(p.test('Introdúcense las siguientes modificaciones en el Código Penal:')).toBe(true)
+    expect(p.test('modifícase el Código Penal')).toBe(true)
+    expect(p.test('la legislación civil, penal, comercial y de procedimiento')).toBe(false)
+    expect(p.test('el procedimiento penal vigente')).toBe(false)
+  })
+
+  it('codPattern handles multi-word names', () => {
+    const p = codPattern('DEL TRABAJO')!
+    expect(p.test('Modifícase el Código del Trabajo en el siguiente sentido:')).toBe(true)
+    expect(p.test('el trabajo de los menores')).toBe(false)
+  })
+
+  it('strictPattern still refuses an incidental article number', () => {
+    const p = strictPattern('dfl', '5')!
+    expect(p.test('el decreto con fuerza de ley N° 5, de 1967')).toBe(true)
+    expect(p.test('lo dispuesto en el artículo 5 de esta ley')).toBe(false)
+  })
+})
+
+describe('nameTokens', () => {
+  it('keeps the discriminating word of a código, which a 7-char floor dropped', () => {
+    expect(nameTokens('CÓDIGO PENAL', [])).toEqual(['penal'])
+    expect(nameTokens('CÓDIGO DE AGUAS', [])).toEqual(['aguas'])
+  })
+
+  it('drops words too generic to identify a law', () => {
+    const toks = nameTokens('FIJA TEXTO REFUNDIDO, COORDINADO Y SISTEMATIZADO DE LA LEY GENERAL', [])
+    expect(toks).toEqual([])
+  })
+
+  it('prefers common names, which is how codes are actually cited', () => {
+    expect(nameTokens('FIJA TEXTO REFUNDIDO … DE LA LEY DE TRÁNSITO', ['LEY DE TRÁNSITO']))
+      .toContain('transito')
+  })
+})
+
+describe('isWholesaleRewrite — corpus artifacts are not legislative history', () => {
+  // Decreto ley 3.346's earliest stored version (1980-05-22) carries the text
+  // of the 2016 ministry rename, so diffing 2012 against it reports all 19
+  // articles modified, backwards. Ley 20.587 amended that law in two places.
+  it('1040829: the decreto ley 3.346 effect is flagged', () => {
+    const { efectos } = fixture('1040829')
+    const dl = efectos.find((e) => e.target.numero === '3346')!
+    expect(dl.articles.length + dl.more).toBeGreaterThanOrEqual(dl.totalArticles)
+    expect(isWholesaleRewrite(dl)).toBe(true)
+  })
+
+  it('does not flag a real amendment, however large the target', () => {
+    const { efectos } = fixture('1040829')
+    // 7 articles of the Código Penal's 579 — a substantial reform, still a
+    // reform. Flagging this would hide exactly what the panel exists to show.
+    expect(isWholesaleRewrite(efectos.find((e) => e.target.numero === 'PENAL')!)).toBe(false)
+    for (const id of ['1192682', '1193517', '1193333']) {
+      for (const e of fixture(id).efectos) expect(isWholesaleRewrite(e)).toBe(false)
+    }
+  })
+
+  it('needs both a high ratio and enough articles', () => {
+    const base = { target: {}, fecha: '2020-01-01', articles: [], more: 0 } as unknown as Efecto
+    // A two-article law with both articles changed is a normal small amendment.
+    expect(isWholesaleRewrite({ ...base, more: 2, totalArticles: 2 })).toBe(false)
+    expect(isWholesaleRewrite({ ...base, more: 8, totalArticles: 9 })).toBe(true)
+    expect(isWholesaleRewrite({ ...base, more: 8, totalArticles: 40 })).toBe(false)
+  })
+})
+
+describe('alignEffects — the case that already worked keeps working', () => {
+  it('1193333: the cooperativas effect stays on the artículo único', () => {
+    const { rows, unmatched } = run('1193333')
+    expect(unmatched).toEqual([])
+    const withEfectos = rows.filter((r) => r.efectos.length > 0)
+    expect(withEfectos).toHaveLength(1)
+    expect(withEfectos[0].article.rawHeading).toBe('Artículo único')
+    expect(targetsOf(withEfectos[0])).toEqual(['dfl 5'])
+  })
+})

--- a/site/lib/efectosAlign.ts
+++ b/site/lib/efectosAlign.ts
@@ -1,0 +1,230 @@
+import type { Segment } from './segment'
+import type { Efecto } from './efectos'
+
+/**
+ * Pairing each effect with the modifier article that caused it.
+ *
+ * Extracted from EfectosPanel so it can be tested against real modificatorias:
+ * every rule here was written against a law that it got wrong, and the fixtures
+ * in `__fixtures__/efectos` are those laws.
+ *
+ * A Chilean modificatoria names its target inside each article — "Modifícase el
+ * decreto con fuerza de ley N° 5, de 1967 … en el siguiente sentido:" — so the
+ * target can be recovered from the article text and matched to the effect on
+ * that same law. That is what lets a change sit beside the article that
+ * produced it rather than in a flat list.
+ *
+ * Heuristic, not a parser. It requires a tipo cue near the number so an
+ * incidental "artículo 5" is not read as "DFL 5"; what no pass claims falls to
+ * "Otras modificaciones", which is a correct answer, just a less useful one.
+ */
+
+const TIPO_CUE: Record<string, string> = {
+  dfl: 'fuerza de ley',
+  dl: 'decreto\\s+ley',
+  dto: 'decreto(?:\\s+supremo)?',
+  ley: 'ley',
+  cod: 'c[oó]digo',
+}
+
+/** Collapse thousands separators inside numbers ("19.882" → "19882") so a bare
+ *  number match is reliable. */
+export function collapseNums(s: string): string {
+  let prev = ''
+  let out = s
+  while (out !== prev) {
+    prev = out
+    out = out.replace(/(\d)\.(\d)/g, '$1$2')
+  }
+  return out
+}
+
+export const fold = (s: string) => s.normalize('NFKD').replace(/[̀-ͯ]/g, '').toLowerCase()
+
+/**
+ * Códigos are named, not numbered: the Código Penal's `numero` is the literal
+ * string "PENAL". Every numeric rule below is therefore a no-op for them, and
+ * before this existed the entire Código Penal block of a criminal-law reform
+ * fell to "Otras modificaciones" — the single most visible mis-alignment in the
+ * panel, since a law amending the Código Penal says so in its first line.
+ */
+export function codPattern(numero: string): RegExp | null {
+  const words = fold(numero)
+    .split(/[^a-z0-9]+/)
+    .filter((w) => w.length >= 3 && w !== 'del' && w !== 'las' && w !== 'los')
+  if (words.length === 0) return null
+  return new RegExp(`c[oó]digo[^.;:]{0,40}?${words.map(escapeRe).join('[^.;:]{0,20}?')}`, 'i')
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/** Strict reference: the tipo cue and the number in proximity. Rules out an
+ *  incidental "artículo 5" being read as "DFL 5". */
+export function strictPattern(tipo: string, numero: string): RegExp | null {
+  if (tipo === 'cod') return codPattern(numero)
+  const num = numero.replace(/\D/g, '')
+  const cue = TIPO_CUE[tipo]
+  if (!num || !cue) return null
+  return new RegExp(`${cue}[^.;:]{0,60}?n[°ºo]?\\s*${num}\\b`, 'i')
+}
+
+/**
+ * Title words too generic to identify a law on their own.
+ *
+ * The minimum token length is 5, not 7: at 7 the discriminating word of most
+ * códigos ("penal", "civil", "aguas", "minas") was silently excluded, which is
+ * why nothing ever matched them by name. Dropping the floor means the stopword
+ * list has to carry the weight instead, so it also holds the short generic
+ * words that a legal title is full of.
+ */
+const NAME_STOPWORDS = new Set([
+  'codigo', 'ley', 'leyes', 'sobre', 'general', 'generales', 'normas', 'norma',
+  'sistema', 'nacional', 'servicio', 'servicios', 'ministerio', 'establece',
+  'texto', 'refundido', 'coordinado', 'sistematizado', 'organica', 'organico',
+  'constitucional', 'materia', 'materias', 'disposiciones', 'aprueba', 'crea',
+  'fija', 'estatuto', 'sector', 'publico', 'del', 'los', 'las', 'para',
+  // Short and generic — only reachable since the length floor dropped to 5.
+  'otras', 'otros', 'nueva', 'nuevo', 'nuevas', 'nuevos', 'dicta', 'chile',
+  'republica', 'decreto', 'decretos', 'fuerza', 'numero', 'articulo',
+  'articulos', 'regula', 'modifica', 'introduce', 'contra', 'entre', 'segun',
+  'dispone', 'aplica', 'vigente', 'anexo', 'parte', 'sera', 'este', 'esta',
+])
+
+const MIN_TOKEN = 5
+
+/** Distinctive words from a target's title and common names ("aeronautico",
+ *  "penal", "municipalidades") — specific enough to identify the law when a
+ *  modifier article names it instead of numbering it. */
+export function nameTokens(titulo: string, comunes: string[]): string[] {
+  const seen = new Set<string>()
+  for (const src of [...comunes, titulo]) {
+    for (const w of fold(src).split(/[^a-z0-9]+/)) {
+      if (w.length >= MIN_TOKEN && !NAME_STOPWORDS.has(w)) seen.add(w)
+    }
+  }
+  return Array.from(seen)
+}
+
+/**
+ * One segment of the modificatoria, with whatever it changed.
+ *
+ * There is a row for *every* segment, including those that changed nothing.
+ * The panel used to render only rows with effects, which silently deleted the
+ * rest of the law: a modificatoria's quoted insertions carry their own
+ * `#### Artículo N` heading, so `segment()` emits them as articles of the
+ * modifier — they are nothing of the sort, they are the text being written into
+ * the target. Ley 21.579 consequently ended at "Agrégase el siguiente artículo
+ * 7° transitorio, nuevo:" with the inserted article nowhere on the page.
+ *
+ * Keeping every segment is also the only honest rendering: this is the tab that
+ * claims to show what a law did, and a reader cannot check that against a text
+ * with holes in it. Segments with no effects render full-width in the panel, so
+ * completeness costs no empty columns.
+ */
+export interface AlignedRow {
+  article: Segment
+  efectos: Efecto[]
+}
+
+/**
+ * Whether an effect is a re-transcription of the whole target rather than a
+ * legislative change to part of it.
+ *
+ * Some normas have a version whose stored text is not the text that was in
+ * force on that date. Decreto ley 3.346 is the clearest case: its *earliest*
+ * version, 1980-05-22, carries the text of the 2016 reform that renamed the
+ * ministry — so diffing the 2012 version against it reports all 19 articles as
+ * modified, and reports them backwards, with the 2016 wording as the "before".
+ * Ley 20.587 then showed a wall of redlines claiming it rewrote a law it
+ * touched in two places. That is the "complete disconnection between cause and
+ * effect" in the report, and its cause is the corpus, not the diff.
+ *
+ * The site cannot repair the text, but it can decline to present a corpus
+ * artifact as legislative history. A genuine modificatoria edits a handful of
+ * articles; one that appears to rewrite nearly every article of its target at
+ * once is almost always a re-transcription, so the panel labels it and folds it
+ * away instead of rendering dozens of false redlines.
+ */
+export function isWholesaleRewrite(e: Efecto): boolean {
+  const changed = e.articles.length + e.more
+  return changed >= WHOLESALE_MIN_ARTICLES && changed >= e.totalArticles * WHOLESALE_RATIO
+}
+
+const WHOLESALE_MIN_ARTICLES = 8
+const WHOLESALE_RATIO = 0.75
+
+/** Don't stack more than a few effects on one article — keeps a fuzzy pass from
+ *  dumping several laws onto one long article. */
+const MAX_PER_ROW = 3
+
+/**
+ * Pair each effect with the modifier article that caused it, then slice the
+ * document so every segment belongs to exactly one row.
+ *
+ * Passes, most confident first:
+ *   1. strict — tipo cue + number in proximity ("fuerza de ley N° 5"), or for a
+ *      código, the cue plus its name ("Código Penal").
+ *   2. number-only — a distinctive number (≥4 digits, so not confusable with an
+ *      article number) anywhere in an as-yet-unmatched article.
+ *   3. by name — a distinctive word of the target's title or common names, for
+ *      laws cited by name rather than number.
+ */
+export function alignEffects(
+  articles: Segment[],
+  efectos: Efecto[],
+): { rows: AlignedRow[]; unmatched: Efecto[] } {
+  const bodies = articles.map((a) => collapseNums(a.body))
+  const folded = bodies.map(fold)
+  const claimed = new Map<number, Efecto[]>()
+  const taken = new Set<number>()
+
+  // The preamble is the law's own title and recitals. It names the target as
+  // loudly as any article does — ley 21.562's is literally "MODIFICA LEY N°
+  // 19.300, SOBRE BASES GENERALES DEL MEDIO AMBIENTE" — but it modifies
+  // nothing, so letting it match put every effect of that law against a block
+  // of front matter instead of against the article that did the work.
+  const eligible = (i: number) =>
+    articles[i].label !== '__preamble__' && articles[i].label !== '__doc__'
+
+  const free = (ai: number) => eligible(ai) && (claimed.get(ai)?.length ?? 0) < MAX_PER_ROW
+  const claim = (ai: number, ei: number, e: Efecto) => {
+    const list = claimed.get(ai)
+    if (list) list.push(e)
+    else claimed.set(ai, [e])
+    taken.add(ei)
+  }
+
+  const assign = (test: (body: string, e: Efecto, ei: number) => boolean) => {
+    efectos.forEach((e, ei) => {
+      if (taken.has(ei)) return
+      const ai = bodies.findIndex((b, i) => free(i) && test(b, e, ei))
+      if (ai >= 0) claim(ai, ei, e)
+    })
+  }
+
+  const strict = efectos.map((e) => strictPattern(e.target.tipo, e.target.numero))
+  assign((body, _e, ei) => !!strict[ei] && strict[ei]!.test(body))
+
+  assign((body, e) => {
+    const num = e.target.numero.replace(/\D/g, '')
+    return num.length >= 4 && new RegExp(`(^|\\D)${num}(\\D|$)`).test(body)
+  })
+
+  const tokens = efectos.map((e) => nameTokens(e.target.titulo, e.target.nombresUsoComun))
+  efectos.forEach((e, ei) => {
+    if (taken.has(ei)) return
+    const toks = tokens[ei]
+    if (toks.length === 0) return
+    const ai = folded.findIndex((fb, i) => free(i) && toks.some((t) => fb.includes(t)))
+    if (ai >= 0) claim(ai, ei, e)
+  })
+
+  const rows: AlignedRow[] = articles.map((article, i) => ({
+    article,
+    efectos: claimed.get(i) ?? [],
+  }))
+  const unmatched = efectos.filter((_, i) => !taken.has(i))
+  return { rows, unmatched }
+}


### PR DESCRIPTION
Three separate defects behind the Efectos reports. Each fixture in `lib/__fixtures__/efectos` is one of the laws you sent, captured from production with the effects the API actually returned, so the tests fail against the old behaviour and pass against this one.

### 1. The left column lost text

A modificatoria quotes the text it inserts, and the pipeline emits that quoted text with its own `#### Artículo N` heading — so `segment()` returns the insertion as if it were an article *of the modifier*. The panel rendered only rows that had effects, which discarded them.

- **[Ley 21.579](https://leyes.pisanvs.cl/norma/1193517)** ended at *"Agrégase el siguiente artículo 7° transitorio, nuevo:"* — the article it inserts was nowhere on the page.
- **[Ley 21.562](https://leyes.pisanvs.cl/norma/1192682)** lost its inserted artículo 43 bis *and* all three transitory articles.

Every segment now gets a row. Rows with no effects render full width rather than beside an empty column — that emptiness is what made showing them read as broken the first time, and dropping them was the wrong cure.

### 2. Effects landed on the wrong article, or on none

A código's `numero` is a **word**: the Código Penal's is the literal string `"PENAL"`. Every numeric rule was a no-op, so no pass could ever match one. **[Ley 20.587](https://leyes.pisanvs.cl/norma/1040829)** opens its artículo 2º with *"Introdúcense las siguientes modificaciones al Código Penal"*, and the whole Código Penal block still fell through to "Otras modificaciones".

`codPattern` matches the cue plus the name. It still declines *"para los penados"* (artículo 1º, which amends DL 321) and *"la legislación civil, penal, comercial"* — which is why it requires the cue rather than the bare word.

`nameTokens` dropped from a 7- to a 5-character floor for the same reason: at 7 it excluded `penal`, `civil`, `aguas`, `minas` — exactly the word that identifies a código. The stopword list now carries that weight instead.

**The preamble no longer matches.** It is the law's own title, so it names the target as loudly as any article — ley 21.562's reads `MODIFICA LEY N° 19.300, SOBRE BASES GENERALES DEL MEDIO AMBIENTE` — and it won every effect of that law, parking it against front matter instead of the article doing the work.

### 3. A backwards diff of an entire law, shown as an amendment

This is the "complete disconnection between cause and effect", and it is **a corpus defect, not a diff defect**:

> `dl 3346` version `1980-05-22` contains *"Ministerio de Justicia **y Derechos Humanos**"* — the 2016 rename.

The earliest stored version carries text from 2016. Diffing the 2012 version against it reports all 19 articles modified *and reports them backwards*, with the 2016 wording as the "before". Ley 20.587 touched that law in two places and displayed a wall of false redlines.

The site cannot repair the text, but it can decline to present it as legislative history. An effect covering ≥75% of its target's articles (min 8) is folded behind a note saying the stored comparison text doesn't correspond to that date. Thresholds come from measured data — the false case is **21 changed of 20 articles**; the real amendments in the fixtures are 7/579, 3/126, 3/255 and 1/146.

### Also found, not fixed here

- **[Ley 19.247](https://leyes.pisanvs.cl/norma/30614)** — its Efectos tab is empty (no target versions are attributed to it), so the formatting you saw is the reader, not this panel. The cause: `Artículo 41 A` is emitted as heading `#### Artículo 41` with the body starting `A.-`, so the law shows two identical "Artículo 41" headings. The marker comes from the pipeline (`scripts/render_texto.py`); `segment()` can't compensate without re-slugging committed text and breaking the validation gate.
- **[Ley 21.562](https://leyes.pisanvs.cl/norma/1192682)** amends articles 2, 11, 16, 43, 43 bis, 44 and 46 of ley 19.300, but the stored 2023-05-29 version only differs in **2°, 43 bis and 44**. Articles 11, 16, 43 and 46 were never updated upstream. Efectos is reporting the corpus faithfully.
- Ley 20.587 also amends DL 321 and ley 20.000, but neither has a version attributed to it, so neither appears.

The matching logic moved to `lib/efectosAlign.ts` — none of it was reachable from a test inside the component, and every rule in it exists because a real law broke the previous one.

`tsc --noEmit` clean · 188 tests pass, 1 skipped (17 new) · `next build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5a463XjtoDsYpMC7Vzhi6
