### PR TITLE
feat(reader): heading tree of the current law in the left rail

### DIFF
--- a/site/components/LawView.tsx
+++ b/site/components/LawView.tsx
@@ -240,7 +240,9 @@ export function LawView({
     // RedlineReader's three ArticleSegment call sites.
     <CiteProvider value={cite ?? null}>
       <IDEShell
-        navigator={<Navigator activeId={idx.norma.idNorma} />}
+        navigator={
+          <Navigator activeId={idx.norma.idNorma} sha={active?.sha} relDir={idx.relDir} />
+        }
         center={center}
         rightRail={<RightRail idx={idx} active={active} activeSlug={activeSlug} />}
         // Efectos shows two panes side by side — let it fill the reading column

--- a/site/components/Navigator.tsx
+++ b/site/components/Navigator.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import Link from 'next/link'
 import { SidebarHeading } from '@/components/IDEShell'
+import { Outline } from '@/components/Outline'
 import { chronologicalNeighbours, type TitleEntry } from '@/lib/titles'
 import { fetchModifications, type ModificationRow } from '@/lib/modifies'
 import { fetchModifiedBy } from '@/lib/modifiedBy'
@@ -37,10 +38,17 @@ function useIdleReady(): boolean {
 interface Props {
   /** idNorma of the law currently on screen — the center of the view. */
   activeId: number
+  /** Version date + rel dir of the text on screen, for the structural outline.
+   *  Absent while no version is resolved, in which case the outline is skipped. */
+  sha?: string
+  relDir?: string
 }
 
 /**
- * Left-rail navigator built for *exploration*. Two stacked groups:
+ * Left-rail navigator. Three stacked groups:
+ *
+ *   0. "Contenido" — the heading tree of the version on screen, for moving
+ *      within the law rather than between laws.
  *
  *   1. "Cronología" — ±3 laws around the active one by publication date,
  *      with the active row highlighted in the middle. Lets you walk the
@@ -52,9 +60,13 @@ interface Props {
  *      so you can see "who else touched this lineage". This is the seed
  *      for the future similarity-based suggestion algorithm.
  */
-export function Navigator({ activeId }: Props) {
+export function Navigator({ activeId, sha, relDir }: Props) {
   return (
     <div className="space-y-6">
+      {/* The law's own structure comes first: the reader is inside this
+          document, and moving within it is the more common need than moving
+          between laws. */}
+      {sha && relDir && <Outline sha={sha} relDir={relDir} />}
       <ChronologyGroup activeId={activeId} />
       <SuggestedGroup activeId={activeId} />
     </div>

--- a/site/components/Outline.tsx
+++ b/site/components/Outline.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+import { SidebarHeading } from '@/components/IDEShell'
+import { fetchRawText } from '@/lib/rawtext'
+import { buildOutline, countNodes, type OutlineNode } from '@/lib/outline'
+
+/**
+ * The law's own structure, in the left rail: Libro → Título → Párrafo →
+ * Artículo, as the pipeline's headings describe it.
+ *
+ * The rail's other groups navigate *between* laws; this one navigates within
+ * the one on screen, which for a code is the only tractable way in — the
+ * Código Penal is 579 articles and no flat list of those is a map.
+ *
+ * The text comes from the same query key RedlineReader uses, so React Query
+ * serves it from cache and the outline costs no extra request.
+ */
+export function Outline({ sha, relDir }: { sha: string; relDir: string }) {
+  const q = useQuery({
+    queryKey: ['rawtext', sha, relDir],
+    queryFn: () => fetchRawText({ sha, relDir }),
+    staleTime: Infinity,
+  })
+
+  const tree = useMemo(() => (q.data ? buildOutline(q.data) : []), [q.data])
+  const active = useActiveAnchor(!!q.data)
+
+  if (q.isLoading) {
+    return (
+      <section className="space-y-2">
+        <SidebarHeading>Contenido</SidebarHeading>
+        <ul className="space-y-1.5 animate-pulse">
+          {[0, 1, 2, 3].map((i) => (
+            <li key={i} className="h-4 bg-paper-sunk/60 rounded" />
+          ))}
+        </ul>
+      </section>
+    )
+  }
+  if (q.isError || tree.length === 0) return null
+
+  return (
+    <section className="space-y-2">
+      <SidebarHeading>Contenido</SidebarHeading>
+      <p className="text-[10px] text-ink-faint -mt-1">
+        {countNodes(tree)} secciones de esta versión.
+      </p>
+      <Branch nodes={tree} depth={0} active={active} />
+    </section>
+  )
+}
+
+/**
+ * Collapse anything deep by default.
+ *
+ * Open, a code's outline is thousands of rows and the rail becomes a second
+ * document to scroll. Títulos stay open so the shape is visible at a glance;
+ * the article lists under them open on demand.
+ */
+const OPEN_THROUGH_DEPTH = 1
+
+function Branch({
+  nodes,
+  depth,
+  active,
+}: {
+  nodes: OutlineNode[]
+  depth: number
+  active: string | null
+}) {
+  return (
+    <ul className={depth > 0 ? 'ml-2 pl-2 border-l border-rule space-y-0.5' : 'space-y-0.5 -mx-1'}>
+      {nodes.map((n, i) => (
+        <Row key={`${n.text}:${i}`} node={n} depth={depth} active={active} />
+      ))}
+    </ul>
+  )
+}
+
+function Row({ node, depth, active }: { node: OutlineNode; depth: number; active: string | null }) {
+  const hasChildren = node.children.length > 0
+  const [open, setOpen] = useState(depth < OPEN_THROUGH_DEPTH)
+  const isActive = !!node.anchor && node.anchor === active
+
+  // A structural heading is the shape of the law; an article is its content.
+  // Weighting them the same makes the rail unreadable at a glance.
+  const tone = node.isArticle
+    ? 'text-[11.5px] text-ink-soft'
+    : 'text-[11.5px] font-medium text-ink'
+
+  return (
+    <li>
+      <div className="flex items-start gap-0.5">
+        {hasChildren ? (
+          <button
+            onClick={() => setOpen((v) => !v)}
+            aria-label={open ? 'Contraer' : 'Expandir'}
+            aria-expanded={open}
+            className="mt-[3px] w-3.5 shrink-0 text-[9px] text-ink-faint hover:text-ink transition"
+          >
+            {open ? '▾' : '▸'}
+          </button>
+        ) : (
+          <span className="w-3.5 shrink-0" aria-hidden />
+        )}
+        {node.anchor ? (
+          <a
+            href={`#${node.anchor}`}
+            className={`block min-w-0 flex-1 rounded px-1 py-0.5 leading-snug transition ${tone} ${
+              isActive ? 'bg-ink text-paper' : 'hover:bg-paper-sunk hover:text-ink'
+            }`}
+            title={node.text}
+          >
+            <span className="line-clamp-2">{node.text}</span>
+          </a>
+        ) : (
+          <span className={`block min-w-0 flex-1 px-1 py-0.5 leading-snug ${tone}`}>
+            <span className="line-clamp-2">{node.text}</span>
+          </span>
+        )}
+      </div>
+      {hasChildren && open && <Branch nodes={node.children} depth={depth + 1} active={active} />}
+    </li>
+  )
+}
+
+/**
+ * The id of the article currently nearest the top of the reading column.
+ *
+ * Observed against the articles the reader has already rendered, rather than
+ * tracked from scroll offsets, so it stays correct when a version change
+ * replaces the whole document. `enabled` gates it until the text has arrived,
+ * since there is nothing to observe before then.
+ */
+function useActiveAnchor(enabled: boolean): string | null {
+  const [active, setActive] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!enabled || typeof IntersectionObserver === 'undefined') return
+    const nodes = document.querySelectorAll<HTMLElement>('[data-article-slug]')
+    if (nodes.length === 0) return
+
+    const visible = new Map<string, number>()
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          const id = e.target.id
+          if (!id) continue
+          if (e.isIntersecting) visible.set(id, e.boundingClientRect.top)
+          else visible.delete(id)
+        }
+        let best: string | null = null
+        let bestTop = Infinity
+        for (const [id, top] of visible) {
+          if (top < bestTop) {
+            bestTop = top
+            best = id
+          }
+        }
+        if (best) setActive(best)
+      },
+      // Ignore the bottom two-thirds: the heading a reader considers "current"
+      // is the one just under the top edge, not whatever else is on screen.
+      { rootMargin: '0px 0px -66% 0px' },
+    )
+    nodes.forEach((n) => io.observe(n))
+    return () => io.disconnect()
+  }, [enabled])
+
+  return active
+}

--- a/site/lib/__fixtures__/outline/codigo-penal-excerpt.md
+++ b/site/lib/__fixtures__/outline/codigo-penal-excerpt.md
@@ -1,0 +1,103 @@
+CÓDIGO PENAL
+
+Santiago, noviembre 12 de 1874.
+
+Núm. 2561.-Para los efectos de la ley de esta fecha, en que se aprueba el Código Penal, nombro una comisión compuesta del Oficial Mayor del Ministerio de Justicia, Culto e Instrucción Pública, don Carlos Riesco, y de los jefes de sección del mismo Ministerio don Manuel Egidio Ballesteros y don Ramón C. Briseño.
+
+Anótese.
+
+ERRÁZURIZ.
+
+JOSE MARIA BARCELÓ
+
+Certificamos que la presente edición del Código Penal está conforme con el proyecto aprobado por el Congreso Nacional.-Santiago, diciembre 15 de 1874.
+
+CARLOS RIESCO.-M. E. BALLESTEROS.-RAMON C. BRISEÑO.
+
+EL PRESIDENTE DE LA REPÚBLICA.
+
+Santiago, noviembre 12 de 1874.
+
+Por cuanto el Congreso Nacional ha aprobado el siguiente
+
+CÓDIGO PENAL.
+
+# Libro Primero
+
+## Título Primero
+
+DE LOS DELITOS Y DE LAS CIRCUNSTANCIAS QUE EXIMEN DE RESPONSABILIDAD CRIMINAL, LA ATENÚAN O LA AGRAVAN.
+
+### I. De los delitos
+
+#### Artículo 1
+Es delito toda acción u omisión voluntaria penada por la ley.
+
+Las acciones u omisiones penadas por la ley se reputan siempre voluntarias, a no ser que conste lo contrario.
+
+El que cometiere delito será responsable de él e incurrirá en la pena que la ley señale, aunque el mal recaiga sobre persona distinta de aquella a quien se proponía ofender. En tal caso no se tomarán en consideración las circunstancias, no conocidas por el delincuente, que agravarían su responsabilidad; pero sí aquellas que la atenúen.
+
+#### Artículo 2
+Las acciones u omisiones que cometidas con dolo o malicia importarían un delito, constituyen cuasidelito si sólo hay culpa en el que las comete.
+
+#### Artículo 3
+Los delitos, atendida su gravedad, se dividen en crímenes, simples delitos y faltas y se califican de tales según la pena que les está asignada en la escala general del art. 21.
+
+#### Artículo 4
+La división de los delitos es aplicable a los cuasidelitos, que se califican y penan en los casos especiales que determina este Código.
+
+#### Artículo 5
+La ley penal chilena es obligatoria para todos los habitantes de la República, inclusos los extranjeros. Los delitos cometidos dentro del mar territorial o adyacente quedan sometidos a las prescripciones de este Código.
+
+#### Artículo 6
+Los crímenes o simples delitos perpetrados fuera del territorio de la República por chilenos o por extranjeros, no serán castigados en Chile sino en los casos determinados por la ley.
+
+#### Artículo 7
+Son punibles, no sólo el crimen o simple delito consumado, sino el frustrado y la tentativa.
+
+Hay crimen o simple delito frustrado cuando el delincuente pone de su parte todo lo necesario para que el crimen o simple delito se consume y esto no se verifica por causas independientes de su voluntad.
+
+Hay tentativa cuando el culpable da principio a la ejecución del crimen o simple delito por hechos directos, pero faltan uno o más para su complemento.
+
+#### Artículo 8
+La conspiración y proposición para cometer un crimen o un simple delito, sólo son punibles en los casos en que la ley las pena especialmente.
+
+La conspiración existe cuando dos o más personas se conciertan para la ejecución del crimen o simple delito.
+
+La proposición se verifica cuando el que ha resuelto cometer un crimen o un simple delito, propone su ejecución a otra u otras personas.
+
+Exime de toda pena por la conspiración o proposición para cometer un crimen o un simple delito, el desistimiento de la ejecución de éstos antes de principiar a ponerlos por obra y de iniciarse procedimiento judicial contra el culpable, con tal que denuncie a la autoridad pública el plan y sus circunstancias.
+
+#### Artículo 9
+Las faltas sólo se castigan cuando han sido consumadas.
+
+### II. De las circunstancias que eximen de responsabilidad criminal
+
+#### Artículo 10
+Están exentos de responsabilidad criminal:
+
+1.° El loco o demente, a no ser que haya obrado en un intervalo lúcido, y el que, por cualquier causa independiente de su voluntad, se halla privado totalmente de razón.
+
+Inciso Derogado.
+
+2.º El menor de dieciocho años. La responsabilidad de los menores de dieciocho años y mayores de catorce se regulará por lo dispuesto en la ley de responsabilidad penal juvenil.
+
+3.° Derogado.
+
+4.° El que obra en defensa de su persona o derechos, siempre que concurran las circunstancias siguientes:
+
+Primera.-Agresión Ilegítima.
+
+Segunda.- Necesidad racional del medio empleado para impedirla o repelerla.
+
+Tercera.-Falta de provocación suficiente por parte del que se defiende.
+
+Inciso Derogado.
+
+5.° El que obra en defensa de la persona o derechos de su cónyuge, de sus parientes consanguíneos legítimos en toda la línea recta y en la colateral hasta el cuarto grado inclusive, de sus afines legítimos en toda la línea recta y en la colateral hasta el segundo grado inclusive, de sus padres o hijos naturales o ilegítimos reconocidos, siempre que concurran la primera y segunda circunstancias prescritas en el número anterior, y la de que, en caso de haber precedido provocación de parte del acometido, no tuviere participación en ella el defensor.
+
+6.° El que obra en defensa de la persona y derechos de un extraño, siempre que concurran las circunstancias expresadas en el número anterior y la de que el defensor no sea impulsado por venganza, resentimiento u otro motivo ilegítimo.
+
+Se presumirá legalmente que concurren las circunstancias previstas en este número y en los números 4° y 5° precedentes, cualquiera que sea el daño que se ocasione al agresor, respecto de aquel que rechaza el escalamiento en los términos indicados en el número 1° del artículo 440 de este Código, en una casa, departamento u oficina habitados, o en sus dependencias o, si es de noche, en un local comercial o industrial y del que impida o trate de impedir la consumación de los delitos señalados en los artículos 141, 142, 361, 362, 365 bis, 390, 391, 433 y 436 de este Código.
+
+7.° El que para evitar un mal ejecuta un hecho, que 

--- a/site/lib/outline.test.ts
+++ b/site/lib/outline.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, it, expect } from 'vitest'
+
+import { buildOutline, countNodes, type OutlineNode } from './outline'
+import { segment } from './segment'
+
+const CODIGO_PENAL = readFileSync(
+  path.join(__dirname, '__fixtures__', 'outline', 'codigo-penal-excerpt.md'),
+  'utf8',
+)
+
+/** Depth-first flattening, for asserting on shape without deep literals. */
+function flatten(nodes: OutlineNode[], depth = 0): string[] {
+  return nodes.flatMap((n) => [`${'  '.repeat(depth)}${n.text}`, ...flatten(n.children, depth + 1)])
+}
+
+describe('buildOutline', () => {
+  it('nests headings by level', () => {
+    const tree = buildOutline(
+      ['# Libro Primero', '## Título I', '#### Artículo 1', 'cuerpo', '## Título II', '#### Artículo 2'].join('\n'),
+    )
+    expect(flatten(tree)).toEqual([
+      'Libro Primero',
+      '  Título I',
+      '    Artículo 1',
+      '  Título II',
+      '    Artículo 2',
+    ])
+  })
+
+  it('reads the real hierarchy of the Código Penal', () => {
+    const tree = buildOutline(CODIGO_PENAL)
+    expect(tree.map((n) => n.text)).toEqual(['Libro Primero'])
+    const titulo = tree[0].children[0]
+    expect(titulo.text).toBe('Título Primero')
+    expect(titulo.children.map((n) => n.text)).toEqual([
+      'I. De los delitos',
+      'II. De las circunstancias que eximen de responsabilidad criminal',
+    ])
+    expect(titulo.children[0].children.map((n) => n.text)).toContain('Artículo 7')
+  })
+
+  it('skips a missing level rather than losing the heading', () => {
+    // `# Libro` straight to `#### Artículo` with no Título between.
+    const tree = buildOutline('# Libro Primero\n#### Artículo 1\ncuerpo')
+    expect(flatten(tree)).toEqual(['Libro Primero', '  Artículo 1'])
+  })
+
+  it('treats a document with no headings as an empty outline', () => {
+    expect(buildOutline('Texto corrido sin encabezados.')).toEqual([])
+  })
+})
+
+describe('outline anchors match what the reader renders', () => {
+  // An outline entry that scrolls nowhere is worse than no entry, so the
+  // anchors are checked against the slugs segment() produces — the same value
+  // ArticleSegment renders as id="art-{slug}".
+  it('every article anchor exists as a segment slug', () => {
+    const slugs = new Set(segment(CODIGO_PENAL).map((s) => `art-${s.slug}`))
+    const articles: OutlineNode[] = []
+    const walk = (ns: OutlineNode[]) =>
+      ns.forEach((n) => {
+        if (n.isArticle) articles.push(n)
+        walk(n.children)
+      })
+    walk(buildOutline(CODIGO_PENAL))
+
+    expect(articles.length).toBeGreaterThan(5)
+    for (const a of articles) expect(slugs).toContain(a.anchor)
+  })
+
+  it('a structural heading inherits the first article beneath it', () => {
+    const tree = buildOutline('## Título I\n### Párrafo 1\n#### Artículo 9\ncuerpo')
+    // Doubled prefix on purpose: labelToSlug already renders "articulo 9" as
+    // "art-9", and ArticleSegment renders id={`art-${slug}`}. The DOM id really
+    // is "art-art-9", so the outline has to emit that and not the tidier form.
+    expect(tree[0].anchor).toBe('art-art-9')
+    expect(tree[0].children[0].anchor).toBe('art-art-9')
+    expect(tree[0].isArticle).toBe(false)
+  })
+
+  it('leaves an anchor null when nothing beneath it is an article', () => {
+    const tree = buildOutline('## Anexo\n### Tabla de valores\ncontenido')
+    expect(tree[0].anchor).toBeNull()
+  })
+})
+
+describe('countNodes', () => {
+  it('counts the whole tree, not just the roots', () => {
+    expect(countNodes(buildOutline('# A\n## B\n## C\n#### Artículo 1'))).toBe(4)
+    expect(countNodes([])).toBe(0)
+  })
+})

--- a/site/lib/outline.ts
+++ b/site/lib/outline.ts
@@ -1,0 +1,92 @@
+import { labelToSlug, normalizeLabel } from './segment'
+
+/**
+ * The structural map of one law: its markdown headings as a tree.
+ *
+ * A long norma is not a list of articles, it is a hierarchy — Libro, Título,
+ * Capítulo, Párrafo, then articles — and the Código Penal has 579 of the last
+ * kind. A flat index of those is not a map of anything. This reads the headings
+ * the pipeline already emits and nests them by level.
+ */
+
+export interface OutlineNode {
+  /** Heading text as written. */
+  text: string
+  /** Markdown heading level, 1-6. */
+  level: number
+  /** Element id to scroll to, or null when nothing in the document carries one. */
+  anchor: string | null
+  /** True for `#### Artículo N`, the leaves the reader renders as segments. */
+  isArticle: boolean
+  children: OutlineNode[]
+}
+
+const HEADING_RE = /^(#{1,6})\s+(\S[^\n]*?)\s*$/gm
+
+// Matches the article headings `segment()` recognises, so the anchor computed
+// here is byte-identical to the `id="art-{slug}"` that ArticleSegment renders.
+// Kept deliberately in step with lib/segment's MD_HEADING_RE: an outline entry
+// that scrolls nowhere is worse than no entry.
+const ARTICLE_RE = /^Art(?:[íi]culo|\.)\b\s+(\S.*)$/i
+
+interface Flat {
+  text: string
+  level: number
+  anchor: string | null
+  isArticle: boolean
+}
+
+function parseFlat(text: string): Flat[] {
+  const out: Flat[] = []
+  for (const m of text.matchAll(HEADING_RE)) {
+    const heading = m[2].trim()
+    const art = ARTICLE_RE.exec(heading)
+    out.push({
+      text: heading,
+      level: m[1].length,
+      isArticle: !!art,
+      anchor: art ? `art-${labelToSlug(normalizeLabel(`articulo ${art[1].trim()}`))}` : null,
+    })
+  }
+  return out
+}
+
+/**
+ * Build the heading tree.
+ *
+ * Structural headings (Título, Capítulo) are rendered by ReactMarkdown inside
+ * an article's body and carry no id of their own, so they inherit the anchor of
+ * the first article beneath them. Clicking "Título II" therefore lands on the
+ * first article of Título II, which is where a reader wanted to go anyway, and
+ * it needs no change to how the readers render.
+ */
+export function buildOutline(text: string): OutlineNode[] {
+  const flat = parseFlat(text)
+  const roots: OutlineNode[] = []
+  const stack: OutlineNode[] = []
+
+  for (const h of flat) {
+    const node: OutlineNode = { ...h, children: [] }
+    while (stack.length > 0 && stack[stack.length - 1].level >= node.level) stack.pop()
+    if (stack.length === 0) roots.push(node)
+    else stack[stack.length - 1].children.push(node)
+    stack.push(node)
+  }
+
+  for (const r of roots) inheritAnchor(r)
+  return roots
+}
+
+/** Give every anchorless node the first anchor found beneath it. */
+function inheritAnchor(node: OutlineNode): string | null {
+  for (const c of node.children) {
+    const a = inheritAnchor(c)
+    if (!node.anchor && a) node.anchor = a
+  }
+  return node.anchor
+}
+
+/** Total nodes in a tree — the sidebar uses it to decide whether to collapse. */
+export function countNodes(nodes: OutlineNode[]): number {
+  return nodes.reduce((n, x) => n + 1 + countNodes(x.children), 0)
+}


### PR DESCRIPTION
The left rail navigated only *between* laws — chronological neighbours, the relational graph — with nothing for moving *inside* the one on screen. For a code that's the difference between usable and not: the Código Penal is 579 articles and the only way through it was scrolling.

### What it shows

A norma isn't a list of articles, it's a hierarchy the pipeline already encodes as markdown headings. The Código Penal really does carry all three levels:

```
# Libro Primero
  ## Título Primero
    ### I. De los delitos
      #### Artículo 1 … 9
    ### II. De las circunstancias que eximen…
```

`buildOutline` nests those by level, so the rail shows the *shape* of the law rather than an index of its leaves. Levels below the first collapse by default — open, a code's outline is a second document to scroll.

### Anchors

Structural headings have no id of their own (ReactMarkdown renders them inside an article's body), so each **inherits the anchor of the first article beneath it**. Clicking "Título II" lands on the first article of Título II — where the reader was going anyway — and it needs no change to how the readers render.

Article anchors go through the same `labelToSlug`/`normalizeLabel` path `ArticleSegment` uses, and a test asserts every one exists as a real segment slug. An outline entry that scrolls nowhere is worse than no entry.

That check also pinned something worth knowing: `labelToSlug` already emits `art-9`, and `ArticleSegment` renders ``id={`art-${slug}`}`` — so the real DOM id is **`art-art-9`**. The outline emits that rather than the tidier form; "fixing" it would silently break every existing deep link.

### Cost

The text comes from the same react-query key `RedlineReader` uses, so it's served from cache — **no extra request**. The active row follows an `IntersectionObserver` over the rendered articles rather than scroll arithmetic, so it stays correct when a version change swaps the document.

Fixture is a real Código Penal excerpt — the case that motivated this.

`tsc --noEmit` clean · 16 tests in the two affected files, 8 new.

### Not verified in a browser

There's no local Postgres here, so the reader page can't be rendered end to end — the parser and anchor computation are tested, the component's layout is not. Worth a look on a deploy preview before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5a463XjtoDsYpMC7Vzhi6
