### PR TITLE
seo: give hub pages their own Open Graph tags, sitemap /citar and /api

### DIFF
--- a/site/app/api/page.tsx
+++ b/site/app/api/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 
-import { SITE } from '@/lib/site'
+import { SITE, SITE_NAME, OG_LOCALE } from '@/lib/site'
 import { CopyBlock } from '@/components/CopyBlock'
 
 /**
@@ -21,12 +21,26 @@ import { CopyBlock } from '@/components/CopyBlock'
  * prerenders as static content.
  */
 
+const OG_TITLE = 'API — el corpus jurídico chileno en JSON'
+const DESCRIPTION =
+  'API REST de sólo lectura sobre las 333.026 normas chilenas: búsqueda, articulado, ' +
+  'versiones históricas y diffs entre ellas. Autenticada con API key.'
+
+// `openGraph` replaces the root layout's object rather than merging into it,
+// so siteName/locale are repeated here — see the note in lib/site.ts. Without
+// this, sharing /api showed the homepage's title/description/url instead.
 export const metadata: Metadata = {
-  title: 'API — el corpus jurídico chileno en JSON',
-  description:
-    'API REST de sólo lectura sobre las 333.026 normas chilenas: búsqueda, articulado, ' +
-    'versiones históricas y diffs entre ellas. Autenticada con API key.',
+  title: OG_TITLE,
+  description: DESCRIPTION,
   alternates: { canonical: `${SITE}/api` },
+  openGraph: {
+    type: 'website',
+    siteName: SITE_NAME,
+    locale: OG_LOCALE,
+    title: OG_TITLE,
+    description: DESCRIPTION,
+    url: `${SITE}/api`,
+  },
 }
 
 const BASE = `${SITE}/api/v1`

--- a/site/app/blog/page.tsx
+++ b/site/app/blog/page.tsx
@@ -1,14 +1,29 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
 import { SITE } from '@/lib/jsonld'
+import { SITE_NAME, OG_LOCALE } from '@/lib/site'
 import { listPosts } from '@/lib/blog'
 import { fechaLarga } from '@/lib/seo'
 
+const OG_TITLE = 'Blog — qué se ve cuando la ley tiene control de versiones'
+const DESCRIPTION =
+  'Casos reales del corpus jurídico chileno: qué cambió en la Ley Karin, cómo leer el texto que regía en una fecha, y qué registra el corpus sobre la ley de datos personales.'
+
+// `openGraph` replaces the root layout's object rather than merging into it,
+// so siteName/locale are repeated here — see the note in lib/site.ts. Without
+// this, sharing /blog showed the homepage's title/description/url instead.
 export const metadata: Metadata = {
-  title: 'Blog — qué se ve cuando la ley tiene control de versiones',
-  description:
-    'Casos reales del corpus jurídico chileno: qué cambió en la Ley Karin, cómo leer el texto que regía en una fecha, y qué registra el corpus sobre la ley de datos personales.',
+  title: OG_TITLE,
+  description: DESCRIPTION,
   alternates: { canonical: `${SITE}/blog` },
+  openGraph: {
+    type: 'website',
+    siteName: SITE_NAME,
+    locale: OG_LOCALE,
+    title: OG_TITLE,
+    description: DESCRIPTION,
+    url: `${SITE}/blog`,
+  },
 }
 
 export default function Page() {

--- a/site/app/cambios/page.tsx
+++ b/site/app/cambios/page.tsx
@@ -7,13 +7,28 @@ import Link from 'next/link'
 import type { Metadata } from 'next'
 import { pool } from '@/lib/db'
 import { SITE } from '@/lib/jsonld'
+import { SITE_NAME, OG_LOCALE } from '@/lib/site'
 import { prettyNumero, tipoLabel } from '@/lib/seo'
 
+const OG_TITLE = 'Qué cambió — historial de modificaciones de las leyes chilenas'
+const DESCRIPTION =
+  'Las normas chilenas que más han cambiado, con cada versión, la norma que la causó y el diff palabra por palabra.'
+
+// `openGraph` replaces the root layout's object rather than merging into it,
+// so siteName/locale are repeated here — see the note in lib/site.ts. Without
+// this, sharing /cambios showed the homepage's title/description/url instead.
 export const metadata: Metadata = {
-  title: 'Qué cambió — historial de modificaciones de las leyes chilenas',
-  description:
-    'Las normas chilenas que más han cambiado, con cada versión, la norma que la causó y el diff palabra por palabra.',
+  title: OG_TITLE,
+  description: DESCRIPTION,
   alternates: { canonical: `${SITE}/cambios` },
+  openGraph: {
+    type: 'website',
+    siteName: SITE_NAME,
+    locale: OG_LOCALE,
+    title: OG_TITLE,
+    description: DESCRIPTION,
+    url: `${SITE}/cambios`,
+  },
 }
 
 interface Row { tipo: string; numero: string; titulo: string; mods: number; versions: number; last: string }

--- a/site/app/guia/page.tsx
+++ b/site/app/guia/page.tsx
@@ -7,14 +7,29 @@ import Link from 'next/link'
 import type { Metadata } from 'next'
 import { pool } from '@/lib/db'
 import { SITE } from '@/lib/jsonld'
+import { SITE_NAME, OG_LOCALE } from '@/lib/site'
 import { GUIA_TIPOS, MIN_GUIA_ARTICLES, prettyNumero, tipoLabel } from '@/lib/seo'
 import { TOPICS } from '@/lib/topics'
 
+const OG_TITLE = 'Guías — qué dice cada ley chilena'
+const DESCRIPTION =
+  'Resumen, articulado y versiones de las leyes, decretos ley, DFL y códigos chilenos. Texto real, no una ficha.'
+
+// `openGraph` replaces the root layout's object rather than merging into it,
+// so siteName/locale are repeated here — see the note in lib/site.ts. Without
+// this, sharing /guia showed the homepage's title/description/url instead.
 export const metadata: Metadata = {
-  title: 'Guías — qué dice cada ley chilena',
-  description:
-    'Resumen, articulado y versiones de las leyes, decretos ley, DFL y códigos chilenos. Texto real, no una ficha.',
+  title: OG_TITLE,
+  description: DESCRIPTION,
   alternates: { canonical: `${SITE}/guia` },
+  openGraph: {
+    type: 'website',
+    siteName: SITE_NAME,
+    locale: OG_LOCALE,
+    title: OG_TITLE,
+    description: DESCRIPTION,
+    url: `${SITE}/guia`,
+  },
 }
 
 interface Row { tipo: string; numero: string; titulo: string; versions: number; arts: number }

--- a/site/app/sitemap-contenido.xml/route.ts
+++ b/site/app/sitemap-contenido.xml/route.ts
@@ -40,6 +40,12 @@ export async function GET() {
     { loc: `${SITE}/cambios` },
     { loc: `${SITE}/temas` },
     { loc: `${SITE}/blog` },
+    // Tool/docs pages with no on-site nav link (the persistent nav only has
+    // room for Temas/Guías/Cambios/Blog) — without a sitemap entry these have
+    // no path to discovery at all. /citar is reachable via the citation blog
+    // posts, but /api had zero internal inlinks anywhere on the site.
+    { loc: `${SITE}/citar` },
+    { loc: `${SITE}/api` },
     ...TOPICS.map((t) => ({ loc: `${SITE}/temas/${t.slug}` })),
     ...listPosts().map((p) => ({
       loc: `${SITE}/blog/${p.slug}`,

--- a/site/app/temas/page.tsx
+++ b/site/app/temas/page.tsx
@@ -1,13 +1,28 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
 import { SITE } from '@/lib/jsonld'
+import { SITE_NAME, OG_LOCALE } from '@/lib/site'
 import { TOPICS } from '@/lib/topics'
 
+const OG_TITLE = 'Temas — las leyes chilenas que más se buscan'
+const DESCRIPTION =
+  'Ley Karin, ley de arriendo, ley del consumidor, ley de datos personales. El nombre coloquial, el número real, y el texto de cada versión.'
+
+// `openGraph` replaces the root layout's object rather than merging into it,
+// so siteName/locale are repeated here — see the note in lib/site.ts. Without
+// this, sharing /temas showed the homepage's title/description/url instead.
 export const metadata: Metadata = {
-  title: 'Temas — las leyes chilenas que más se buscan',
-  description:
-    'Ley Karin, ley de arriendo, ley del consumidor, ley de datos personales. El nombre coloquial, el número real, y el texto de cada versión.',
+  title: OG_TITLE,
+  description: DESCRIPTION,
   alternates: { canonical: `${SITE}/temas` },
+  openGraph: {
+    type: 'website',
+    siteName: SITE_NAME,
+    locale: OG_LOCALE,
+    title: OG_TITLE,
+    description: DESCRIPTION,
+    url: `${SITE}/temas`,
+  },
 }
 
 export default function Page() {


### PR DESCRIPTION
## Problem

`/guia`, `/blog`, `/temas`, `/cambios` and `/api` each set `title`/`description`/`alternates.canonical` in their `metadata` export, but none set their own `openGraph` object.

Next's metadata merge replaces a top-level key wholesale rather than merging into it (documented in `site/lib/site.ts`'s comment on `app/layout.tsx`). A route with no `openGraph` field therefore fully inherits the **root layout's** `openGraph` — which is the homepage's title/description/url. Confirmed live before this fix:

```
$ curl -s https://leyes.pisanvs.cl/cambios | grep 'og:title\|og:url'
<meta property="og:title" content="El corpus jurídico chileno, en formato amigable"/>
<meta property="og:url" content="https://leyes.pisanvs.cl"/>
```

Sharing any of these five pages on Slack/Twitter/Facebook/etc. showed the homepage's card, not the page's own — same class of bug PR #20 fixed on the norma/guia-detail/blog-post routes, but these five index pages were missed (and `/citar` was just fixed separately in #32).

Also: `/citar` and `/api` are absent from `sitemap-contenido.xml` and from the persistent site nav (`TopBar.tsx`, which only has room for Temas/Guías/Cambios/Blog). `/citar` is at least reachable via the three citation blog posts that link to it, but `/api` had **zero internal inlinks anywhere on the site** — genuinely orphaned, undiscoverable by crawlers without an external backlink or manual GSC submission.

## Fix

- Add a page-specific `openGraph` block (`type`, `siteName`, `locale`, `title`, `description`, `url`) to `/guia`, `/blog`, `/temas`, `/cambios`, `/api`, matching the pattern already used by `temas/[slug]` and `/citar` (#32). Hoisted the repeated title/description strings into `OG_TITLE`/`DESCRIPTION` consts so `metadata.title`/`.description` and `metadata.openGraph.title`/`.description` can't drift apart.
- Add `/citar` and `/api` to `sitemap-contenido.xml`'s entries list.

## Verification

```
$ npx tsc --noEmit
(clean)

$ DATABASE_URL= pnpm build        # matches the Railway image: no DB reachable at build time
✓ Compiled successfully
✓ Generating static pages using 3 workers (56/56)

$ pnpm vitest run
 Test Files  23 passed | 1 skipped (24)
      Tests  166 passed | 1 skipped (167)
```

(Ran `rm -rf .next` before the vitest run — a stray `.next/standalone` build directory otherwise gets picked up by Vitest's default include glob and fails on unrelated missing-module errors. Pre-existing `vitest.config.ts` gap, unrelated to this change, not touched here — filed separately in today's audit report.)

Live spot-check after the equivalent fix, reasoned through the same code path used by `temas/[slug]` (already confirmed working in production) — this PR applies the identical object shape to the five remaining routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKdEUH4ND9onwQrWK46a4i

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKdEUH4ND9onwQrWK46a4i)_