### PR TITLE
seo: /guia and /cambios index pages link by idNorma, not ambiguous key

### DIFF
--- a/site/app/cambios/page.tsx
+++ b/site/app/cambios/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import type { Metadata } from 'next'
 import { pool } from '@/lib/db'
 import { SITE } from '@/lib/jsonld'
+import { cambiosHref } from '@/lib/href'
 import { prettyNumero, tipoLabel } from '@/lib/seo'
 
 export const metadata: Metadata = {
@@ -16,13 +17,16 @@ export const metadata: Metadata = {
   alternates: { canonical: `${SITE}/cambios` },
 }
 
-interface Row { tipo: string; numero: string; titulo: string; mods: number; versions: number; last: string }
+interface Row {
+  idNorma: number; tipo: string; numero: string; titulo: string
+  mods: number; versions: number; last: string
+}
 
 /** Normas with the deepest change history. Same reasoning as /guia's index:
  *  a doorway, not a dump of 5.4k links. */
 async function notable(): Promise<Row[]> {
   const { rows } = await pool.query(
-    `SELECT n.tipo, n.numero, n.titulo,
+    `SELECT n.id_norma, n.tipo, n.numero, n.titulo,
             count(DISTINCT v.desde)::int AS versions,
             (SELECT count(*) FROM modificacion m WHERE m.target_id = n.id_norma)::int AS mods,
             max(v.desde)::text AS last
@@ -35,7 +39,7 @@ async function notable(): Promise<Row[]> {
       LIMIT 40`,
   )
   return rows.map((r) => ({
-    tipo: r.tipo, numero: r.numero, titulo: r.titulo,
+    idNorma: r.id_norma, tipo: r.tipo, numero: r.numero, titulo: r.titulo,
     mods: r.mods, versions: r.versions, last: r.last,
   }))
 }
@@ -57,9 +61,9 @@ export default async function Page() {
 
         <ul className="mt-12 divide-y divide-rule border-t border-rule">
           {rows.map((r) => (
-            <li key={`${r.tipo}-${r.numero}-${r.last}`}>
+            <li key={r.idNorma}>
               <Link
-                href={`/cambios/${r.tipo}/${encodeURIComponent(r.numero)}`}
+                href={cambiosHref(r)}
                 className="group flex flex-col md:flex-row md:items-baseline gap-1 md:gap-6 py-3.5 hover:bg-paper-sunk/50 -mx-2 px-2 rounded transition"
               >
                 <div className="font-mono text-xs text-ink-faint w-32 shrink-0">

--- a/site/app/guia/page.tsx
+++ b/site/app/guia/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import type { Metadata } from 'next'
 import { pool } from '@/lib/db'
 import { SITE } from '@/lib/jsonld'
+import { guiaHref } from '@/lib/href'
 import { GUIA_TIPOS, MIN_GUIA_ARTICLES, prettyNumero, tipoLabel } from '@/lib/seo'
 import { TOPICS } from '@/lib/topics'
 
@@ -17,7 +18,9 @@ export const metadata: Metadata = {
   alternates: { canonical: `${SITE}/guia` },
 }
 
-interface Row { tipo: string; numero: string; titulo: string; versions: number; arts: number }
+interface Row {
+  idNorma: number; tipo: string; numero: string; titulo: string; versions: number; arts: number
+}
 
 /** The most-reformed normas that clear the guide gate. "Most versions" is a
  *  decent proxy for "most consequential": a law nobody amends is a law nobody
@@ -28,7 +31,7 @@ interface Row { tipo: string; numero: string; titulo: string; versions: number; 
  *  and 500s this route on production Postgres. See MIN_GUIA_ARTICLES. */
 async function notable(): Promise<Row[]> {
   const { rows } = await pool.query(
-    `SELECT n.tipo, n.numero, n.titulo, a.arts::int AS arts, count(v.*)::int AS versions
+    `SELECT n.id_norma, n.tipo, n.numero, n.titulo, a.arts::int AS arts, count(v.*)::int AS versions
        FROM norma n
        JOIN (
          SELECT id_norma, count(*) AS arts FROM articulo GROUP BY id_norma
@@ -41,7 +44,8 @@ async function notable(): Promise<Row[]> {
     [GUIA_TIPOS as unknown as string[], MIN_GUIA_ARTICLES],
   )
   return rows.map((r) => ({
-    tipo: r.tipo, numero: r.numero, titulo: r.titulo, versions: r.versions, arts: r.arts,
+    idNorma: r.id_norma, tipo: r.tipo, numero: r.numero, titulo: r.titulo,
+    versions: r.versions, arts: r.arts,
   }))
 }
 
@@ -80,9 +84,9 @@ export default async function Page() {
         </p>
         <ul className="divide-y divide-rule border-t border-rule">
           {rows.map((r) => (
-            <li key={`${r.tipo}-${r.numero}`}>
+            <li key={r.idNorma}>
               <Link
-                href={`/guia/${r.tipo}/${encodeURIComponent(r.numero)}`}
+                href={guiaHref(r)}
                 className="group flex flex-col md:flex-row md:items-baseline gap-1 md:gap-6 py-3.5 hover:bg-paper-sunk/50 -mx-2 px-2 rounded transition"
               >
                 <div className="font-mono text-xs text-ink-faint w-28 shrink-0">


### PR DESCRIPTION
## Problem

The `/guia` and `/cambios` hub pages list the "most reformed" / "most modified" normas and link to each one as `/guia/{tipo}/{numero}` or `/cambios/{tipo}/{numero}` — the legacy, ambiguous key form.

`lib/href.ts` already has `guiaHref()`/`cambiosHref()` precisely to avoid this. Its comment documents the history: `/guia/dfl/1` used to silently write a guide about "whichever DFL 1 sorted first"; the `[...rest]` route was fixed to instead redirect an ambiguous key to the plain reader disambiguation hub rather than guess. But `app/guia/page.tsx` and `app/cambios/page.tsx`'s `notable()` queries never picked up `id_norma`, so their index links kept using the ambiguous `(tipo, numero)` form.

Since `(tipo, numero)` is ambiguous for ~91.7% of the corpus, and "most reformed" skews toward old, heavily-reused numbers (227 distinct normas share the key DFL 1, 75 share DFL 4), most of the flagship entries on these two hub pages now link into a dead end instead of any content.

Confirmed live before this fix:
```
/guia/dfl/1    → 308 → /dfl/1     (bare disambiguation hub, no guide)
/guia/dfl/2    → 308 → /dfl/2     (same)
/guia/dfl/3    → 308 → /dfl/3     (same)
/guia/dfl/4    → 308 → /dfl/4     (same)
/guia/dfl/251  → 308 → /dfl/251   (same)
/guia/cod/PENAL         → 308 → /guia/1984/cod-penal-codigo-penal   (fine — cod keys are unique)
```
4 of the first 6 non-código entries on the `/guia` hub were broken this way; `/cambios` has the identical bug for the same reason (same query shape, same missing `id_norma`).

**Impact:** the site's two most important content hubs burn internal link equity into off-topic redirects, and the on-site navigation path into `/guia`/`/cambios` content is broken for a large share of entries (still reachable via `sitemap-contenido.xml`, so not orphaned — but not reachable by clicking through the hub, which is the point of having one).

## Fix

Select `id_norma` in both `notable()` queries (it was already in `GROUP BY`, just missing from `SELECT`), carry it on `Row`, and build links with `guiaHref()`/`cambiosHref()` — the same helpers the `[...rest]` pages and the content sitemap already use for these exact canonical URLs.

## Verification

- `npx tsc --noEmit` — clean
- `pnpm build` with no `DATABASE_URL` (matching the Railway/CI image) — succeeds:
  ```
  ✓ Compiled successfully in 10.9s
  ✓ Generating static pages using 3 workers (56/56)
  ```
- `pnpm vitest run` (with a clean `.next/` — a stale build directory otherwise leaks stale test copies into the run, unrelated to this change) — `166 passed | 1 skipped`, unchanged from before this diff
- Live cross-check: verified idNorma-keyed URLs resolve correctly via `get_law`/`search_laws` against the corpus for a couple of the previously-broken entries

## Scope

Two files, additive-only query change (`SELECT` gains one already-grouped column) plus swapping a hand-built href for the existing helper. No behavior change to the `[...rest]` resolution logic, the sitemap, or the guide/cambios gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwWGezc5p1gSV5nRJ6Lf2S

---
_Generated by [Claude Code](https://claude.ai/code/session_01SwWGezc5p1gSV5nRJ6Lf2S)_