### PR TITLE
seo: document idNorma param on every /llms.txt MCP tool signature

### DIFF
--- a/site/app/llms.txt/route.ts
+++ b/site/app/llms.txt/route.ts
@@ -30,14 +30,14 @@ Servidor MCP remoto, Streamable HTTP, sólo lectura, sin autenticación:
 
 Herramientas disponibles:
 
-- search_laws(query, asOf?)                      — buscar normas en todo el corpus
-- search_articles(tipo, numero, query, fecha?)   — buscar dentro de UNA norma
-- get_law(tipo, numero, fecha?)                  — metadatos + índice de artículos + versiones
-- get_article(tipo, numero, articulo, fecha?)    — el texto de un artículo
-- list_versions(tipo, numero)                    — cada fecha en que la norma cambió, y qué la causó
-- get_raw_link(tipo, numero, asOf?)              — enlaces al texto íntegro sin recortar (y al commit que lo publicó)
-- diff_versions(tipo, numero, desde, hasta)      — qué cambió entre dos versiones (diff palabra por palabra)
-- get_modifications(tipo, numero)                — grafo modificadora → modificada
+- search_laws(query, asOf?)                              — buscar normas en todo el corpus
+- search_articles(tipo, numero, query, fecha?, idNorma?) — buscar dentro de UNA norma
+- get_law(tipo, numero, fecha?, idNorma?)                — metadatos + índice de artículos + versiones
+- get_article(tipo, numero, articulo, fecha?, idNorma?)  — el texto de un artículo
+- list_versions(tipo, numero, idNorma?)                  — cada fecha en que la norma cambió, y qué la causó
+- get_raw_link(tipo, numero, asOf?, idNorma?)            — enlaces al texto íntegro sin recortar (y al commit que lo publicó)
+- diff_versions(tipo, numero, desde, hasta, idNorma?)    — qué cambió entre dos versiones (diff palabra por palabra)
+- get_modifications(tipo, numero, idNorma?)              — grafo modificadora → modificada
 
 Añadirlo a Claude: Settings → Connectors → Add custom connector → ${SITE}/api/mcp
 Claude Code: claude mcp add --transport http leychile ${SITE}/api/mcp
@@ -45,6 +45,12 @@ Claude Code: claude mcp add --transport http leychile ${SITE}/api/mcp
 Nota: una norma puede tener ~350 KB de texto. get_law devuelve un índice de
 artículos, no el texto completo; pide los artículos de a uno con get_article, o
 usa search_articles para ubicar el artículo relevante primero.
+
+Nota: (tipo, numero) NO identifica una norma — es ambiguo para ~91.7% del
+corpus (hay 227 normas con clave "DFL 1", 75 con "DFL 4"). Si es ambiguo,
+la herramienta devuelve la lista de candidatas con su idNorma en vez de
+adivinar; vuelve a llamar pasando ese idNorma para elegir una. search_laws
+también devuelve idNorma en cada resultado.
 
 ## HTTP (si no hablas MCP)
 


### PR DESCRIPTION
**Problem**

Every MCP tool except `search_laws` actually accepts an optional `idNorma` parameter — confirmed by loading the live tool schemas via the attached Ley-Chile MCP connector and calling `get_law`/`search_laws` directly. Each tool's own description stresses this heavily: `(tipo, numero)` is ambiguous for ~91.7% of the corpus (227 normas share the key "DFL 1", 75 share "DFL 4"), and when the key is ambiguous the tool returns a list of `idNorma` candidates instead of guessing.

`/llms.txt` is the documented front door for agents (`site/app/llms.txt/route.ts`) but never mentioned this parameter or the disambiguation flow — an agent following only the doc would hit an ambiguous-key candidate list with no idea how to resolve it into a follow-up call.

Live repro before the fix:
```
$ get_law(tipo="dfl", numero="1")
Hay 227 normas con clave DFL 1, distinguibles por organismo y año. (tipo, número)
no identifica una norma chilena — LeyChile usa idNorma. Vuelve a llamar con el
idNorma deseado (o usa search_laws para acotar por texto): ...
```
— but `idNorma?` never appeared anywhere in `/llms.txt`'s tool list.

**Fix**

Adds `idNorma?` to each tool's listed signature and a short paragraph explaining the disambiguation flow (mirrors the tools' own descriptions), matching what the live MCP server actually exposes.

**Verification**
- `npx tsc --noEmit` — clean
- `pnpm build` with no `DATABASE_URL` (matching Railway/CI) — succeeds
- `pnpm vitest run` (clean `.next/`) — 166 passed | 1 skipped, unchanged
- Live: fetched schemas for all 8 MCP tools and cross-checked param names against the new doc text

**Scope:** one file, doc-only text change inside the static `/llms.txt` route — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3akFUGpJHCDQBFUUW976S

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3akFUGpJHCDQBFUUW976S)_