### PR TITLE
seo: fix /temas hub links and meta description truncation

### DIFF
--- a/site/app/temas/[slug]/page.tsx
+++ b/site/app/temas/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { breadcrumbJsonLd, jsonLdScript, SITE } from '@/lib/jsonld'
-import { canonicalHref } from '@/lib/href'
+import { canonicalHref, cambiosHref, guiaHref } from '@/lib/href'
 import { getModifiedBy, getVersions } from '@/lib/norma'
 import {
   fechaLarga, getGuiaStats, getSeoNorma, normaLabel, qualifiesForCambios, qualifiesForGuia, tipoLabel,
@@ -40,7 +40,6 @@ async function resolveRefs(t: Topic): Promise<ResolvedRef[]> {
     const [versions, stats, modifiedBy] = await Promise.all([
       getVersions(n.idNorma), getGuiaStats(n.idNorma), getModifiedBy(n.idNorma),
     ])
-    const enc = encodeURIComponent(n.numero)
     out.push({
       ref,
       label: normaLabel(n),
@@ -48,19 +47,32 @@ async function resolveRefs(t: Topic): Promise<ResolvedRef[]> {
       fechaPublicacion: n.fechaPublicacion,
       versions: versions.length,
       derogado: n.derogado,
-      guia: qualifiesForGuia(n, stats) ? `/guia/${n.tipo}/${enc}` : null,
-      cambios: qualifiesForCambios(versions, modifiedBy.length) ? `/cambios/${n.tipo}/${enc}` : null,
+      // idNorma-keyed, like the /guia and /cambios index pages: (tipo, numero)
+      // is ambiguous for ~91.7% of the corpus, so the legacy key form 308s
+      // through a disambiguation hub instead of landing on this norma's guide.
+      guia: qualifiesForGuia(n, stats) ? guiaHref(n) : null,
+      cambios: qualifiesForCambios(versions, modifiedBy.length) ? cambiosHref(n) : null,
       reader: canonicalHref(n),
     })
   }
   return out
 }
 
+/** Cut `s` to at most `max` chars without breaking mid-word — `t.intro.slice(0,
+ *  180)` used to land inside a word (e.g. "...prevención, investigaci"),
+ *  which reads as broken in a SERP snippet or a social card. */
+function truncateAtWord(s: string, max: number): string {
+  if (s.length <= max) return s
+  const cut = s.slice(0, max)
+  const lastSpace = cut.lastIndexOf(' ')
+  return `${(lastSpace > 0 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`
+}
+
 export async function generateMetadata({ params }: Props) {
   const { slug } = await params
   const t = getTopic(slug)
   if (!t) return {}
-  const description = t.intro.slice(0, 180)
+  const description = truncateAtWord(t.intro, 180)
   return {
     title: t.title,
     description,


### PR DESCRIPTION
Two bugs found auditing `/temas/[slug]`:

**1. Ambiguous-key links to /guia and /cambios**

`resolveRefs()` in `site/app/temas/[slug]/page.tsx` built `guia`/`cambios` links by hand as `` `/guia/${n.tipo}/${enc}` `` / `` `/cambios/${n.tipo}/${enc}` `` — the legacy, ambiguous `(tipo, numero)` key form. `(tipo, numero)` is ambiguous for ~91.7% of the corpus, so any topic ref whose key collides would 308 through the plain reader disambiguation hub instead of landing on that norma's guide — the same class of bug [#39](https://github.com/pisanvs/ley-chile/pull/39) fixes for the `/guia` and `/cambios` index pages themselves. None of the current curated topic refs happen to collide today, but the bug is live in the code path and would silently break the first ref that does.

Fixed by switching to the existing `guiaHref()`/`cambiosHref()` helpers from `lib/href.ts` (idNorma-keyed), the same convention `/guia`, `/cambios`, and the content sitemap already use — `getSeoNorma()`'s return value already satisfies the `IdentifiableNorma` shape they need, so this also let me drop the now-unused `enc` variable.

**2. Meta/OG/Twitter description cut mid-word**

`generateMetadata()` did `t.intro.slice(0, 180)` — a hard character cut with no word boundary. Live on `/temas/ley-karin` before this fix:

```
$ curl -s https://leyes.pisanvs.cl/temas/ley-karin | grep 'meta name="description"'
<meta name="description" content="La Ley Karin es la Ley 21.643, publicada el 15 de
enero de 2024. Su título oficial es «Modifica el Código del Trabajo y otros cuerpos
legales, en materia de prevención, investigaci"/>
```
Cut off mid-word ("investigaci[ón]"), no ellipsis — reads as broken in a SERP snippet or a social share card. Same `description` feeds `<meta name="description">`, `og:description`, and `twitter:description`, so all three were affected.

Added a small `truncateAtWord()` helper that cuts on the last space within the limit and appends `…`.

**Verification**
- `npx tsc --noEmit` — clean
- `pnpm build` with no `DATABASE_URL` (matching Railway/CI) — succeeds
- `pnpm vitest run` (clean `.next/`) — 166 passed | 1 skipped, unchanged
- Confirmed the mid-word cut live via `curl` before applying the fix (shown above)

**Scope:** one file (`site/app/temas/[slug]/page.tsx`), additive-only — new import, one helper function, swapped href construction, no change to the guide/cambios qualification gate or any other route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3akFUGpJHCDQBFUUW976S

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3akFUGpJHCDQBFUUW976S)_